### PR TITLE
20260217 1813 update

### DIFF
--- a/智绘教/IdtMain.cpp
+++ b/智绘教/IdtMain.cpp
@@ -51,7 +51,7 @@ import Inkeys.Other.Gesture;
 #pragma comment(lib, "netapi32.lib")
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
-wstring editionDate = L"20260217a";				// 程序发布日期
+wstring editionDate = L"20260217b";				// 程序发布日期
 wstring editionChannel = L"Canary";				// 程序发布通道
 
 wstring userId;									// 用户GUID

--- a/智绘教/智绘教.vcxproj
+++ b/智绘教/智绘教.vcxproj
@@ -159,6 +159,7 @@
       </CompileAsManaged>
       <GenerateSourceDependencies>true</GenerateSourceDependencies>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -230,6 +231,7 @@
       </CompileAsManaged>
       <GenerateSourceDependencies>true</GenerateSourceDependencies>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -299,6 +301,7 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Update build metadata and enable source scanning for module dependencies.

- IdtMain.cpp: bump editionDate from "20260217a" to "20260217b" to mark the new release.
- *.vcxproj: add <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies> to several <ClCompile> configurations so MSVC will scan source files for C++ module dependencies during compilation.

These changes ensure the build picks up module dependency info and reflect the updated edition/version.