### PR TITLE
Use per-arch vcpkg cache; remove NuGet feed

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -62,9 +62,8 @@ jobs:
       fail-fast: false
     runs-on: windows-2025
     env:
-      USERNAME: ${{ github.repository_owner }}
-      FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
+      VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}\.vcpkg-bincache\${{ matrix.platform }},readwrite'
+
 
     steps:
     - name: Checkout code 
@@ -83,6 +82,30 @@ jobs:
         echo "OS=$os" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         echo "OS_VERSION=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+    - name: Prepare vcpkg cache dirs
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path ".\.vcpkg-bincache\${{ matrix.platform }}" | Out-Null
+        New-Item -ItemType Directory -Force -Path ".\vcpkg\downloads" | Out-Null
+
+    - name: Get vcpkg submodule SHA
+      id: vcpkg_sha
+      shell: pwsh
+      run: |
+        $sha = (git -C vcpkg rev-parse HEAD).Trim()
+        "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Restore vcpkg binary cache (per-arch)
+      uses: actions/cache@v4
+      with:
+        path: |
+          .\.vcpkg-bincache\${{ matrix.platform }}
+          .\vcpkg\downloads
+        key: vcpkg-${{ runner.os }}-${{ matrix.platform }}-${{ env.ImageVersion }}-${{ steps.vcpkg_sha.outputs.sha }}-${{ hashFiles('vcpkg.json', 'Directory.Build.props', 'Directory.Build.targets') }}
+        restore-keys: |
+          vcpkg-${{ runner.os }}-${{ matrix.platform }}-${{ env.ImageVersion }}-${{ steps.vcpkg_sha.outputs.sha }}-
+          vcpkg-${{ runner.os }}-${{ matrix.platform }}-${{ env.ImageVersion }}-
+          vcpkg-${{ runner.os }}-${{ matrix.platform }}-
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
     - name: Setup NuGet
@@ -155,32 +178,6 @@ jobs:
     - name: Bootstrap vcpkg
       shell: pwsh
       run: .\vcpkg\bootstrap-vcpkg.bat
-      
-    - name: Configure NuGet source for vcpkg binary cache
-      shell: pwsh
-      run: |
-        # Fetch vcpkg-provided nuget.exe (prints path)
-        $nugetPath = .\vcpkg\vcpkg.exe fetch nuget | Select-Object -Last 1
-        if (-not (Test-Path $nugetPath)) {
-          throw "nuget.exe not found at: $nugetPath"
-        }
-
-        $sourceName = "GitHubPackages"
-        $feedUrl    = "${{ env.FEED_URL }}"
-        $userName   = "${{ env.USERNAME }}"
-        $token      = "${{ secrets.GITHUB_TOKEN }}"
-
-        # Add or update the NuGet source (idempotent)
-        $existing = & $nugetPath sources list | Out-String
-        if ($existing -match [regex]::Escape($sourceName)) {
-          & $nugetPath sources update -Name $sourceName -Source $feedUrl -UserName $userName -Password $token
-        } else {
-          & $nugetPath sources add    -Name $sourceName -Source $feedUrl -UserName $userName -Password $token
-        }
-
-        # Set API key for pushing packages (required for readwrite feeds)
-        & $nugetPath setapikey $token -Source $feedUrl
-        
     - name: Build Inkeys
       run: msbuild "智绘教.sln" /p:Configuration=Release /p:Platform=${{ matrix.platform }} /p:PlatformToolset=v143 /verbosity:minimal
       shell: cmd

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   actions: write
-  packages: write
 
 jobs:
   check:


### PR DESCRIPTION
Replace GitHub Packages binary feed with a file-based, per-architecture vcpkg bincache. Set VCPKG_BINARY_SOURCES to point at ./.vcpkg-bincache/${{ matrix.platform }}, remove USERNAME and FEED_URL env vars, and drop the NuGet configuration step. Add steps to prepare cache dirs, capture the vcpkg submodule SHA, and restore .vcpkg-bincache and vcpkg downloads via actions/cache@v4 using a cache key that includes runner, platform, image version, vcpkg SHA, and hashes of vcpkg.json / Directory.Build.* to ensure proper cache invalidation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **杂项**
  * 优化了构建工作流程的缓存机制，改为按架构的文件基础缓存以提高构建性能。
  * 调整了工作流权限配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->