### PR TITLE
Use Build/*/Release paths for artifacts

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -163,12 +163,12 @@ jobs:
                   matrix.platform == 'x64' && 'Inkeys64[Unsigned]' || 
                   matrix.platform == 'ARM64' && 'InkeysArm64[Unsigned]' }}
         path: |
-          ${{ (matrix.platform == 'Win32' && './Release/Inkeys.exe') || 
-              (matrix.platform == 'x64' && './x64/Release/Inkeys.exe') || 
-              (matrix.platform == 'ARM64' && './ARM64/Release/Inkeys.exe') }}
-          ${{ (matrix.platform == 'Win32' && './Release/Inkeys.pdb') ||
-              (matrix.platform == 'x64' && './x64/Release/Inkeys.pdb') ||
-              (matrix.platform == 'ARM64' && './ARM64/Release/Inkeys.pdb') }}
+          ${{ (matrix.platform == 'Win32' && './Build/Win32/Release/Inkeys.exe') || 
+              (matrix.platform == 'x64' && './Build/x64/Release/Inkeys.exe') || 
+              (matrix.platform == 'ARM64' && './Build/ARM64/Release/Inkeys.exe') }}
+          ${{ (matrix.platform == 'Win32' && './Build/Win32/Release/Inkeys.pdb') ||
+              (matrix.platform == 'x64' && './Build/x64/Release/Inkeys.pdb') ||
+              (matrix.platform == 'ARM64' && './Build/ARM64/Release/Inkeys.pdb') }}
           
   package:
     name: Package


### PR DESCRIPTION
Update .github/workflows/msbuild.yml to point artifact upload paths to the Build/<platform>/Release directories for Win32, x64, and ARM64. This updates the paths for both Inkeys.exe and Inkeys.pdb so the workflow finds the compiled outputs in the Build subfolders.