### PR TITLE
Migrate from CComPtr to WRL::ComPtr

### DIFF
--- a/智绘教/IdtD2DPreparation.cpp
+++ b/智绘教/IdtD2DPreparation.cpp
@@ -8,21 +8,40 @@ ComPtr<IDWriteFontCollection> dWriteFontCollection;
 ComPtr<ID3D11Device> d3dDevice_WARP;
 ComPtr<ID2D1Device> d2dDevice_WARP;
 
-void D2DStarup()
+HRESULT D2DStarup()
 {
-	// 创建 D2D1.1 工厂
-	D2D1CreateFactory(
+	auto resetState = []()
+		{
+			d2dDevice_WARP.Reset();
+			d3dDevice_WARP.Reset();
+			dWriteFontCollection.Reset();
+			dWriteFactory1.Reset();
+			d2dFactory1.Reset();
+		};
+
+	HRESULT hr = D2D1CreateFactory(
 		D2D1_FACTORY_TYPE_MULTI_THREADED,
 		__uuidof(ID2D1Factory1),
 		NULL,
 		reinterpret_cast<void**>(d2dFactory1.ReleaseAndGetAddressOf())
 	);
+	if (FAILED(hr))
+	{
+		resetState();
+		return hr;
+	}
 
-	DWriteCreateFactory(
+	// 创建 D2D1.1 工厂
+	hr = DWriteCreateFactory(
 		DWRITE_FACTORY_TYPE_SHARED,
 		__uuidof(IDWriteFactory1),
 		reinterpret_cast<IUnknown**>(dWriteFactory1.ReleaseAndGetAddressOf())
 	);
+	if (FAILED(hr))
+	{
+		resetState();
+		return hr;
+	}
 
 	// 初始化 DC
 	{
@@ -35,7 +54,7 @@ void D2DStarup()
 			D3D_FEATURE_LEVEL_11_0,
 		};
 
-		D3D11CreateDevice(
+		hr = D3D11CreateDevice(
 			nullptr,                    // 指定 nullptr 使用默认适配器
 			D3D_DRIVER_TYPE_WARP,       // **关键：使用 WARP 软件渲染器**
 			nullptr,                    // 没有软件模块
@@ -47,15 +66,34 @@ void D2DStarup()
 			nullptr,                    // 返回实际的功能级别
 			nullptr                     // 返回设备上下文 (我们不需要)
 		);
+		if (FAILED(hr))
+		{
+			resetState();
+			return hr;
+		}
 
 		ComPtr<IDXGIDevice> dxgiDevice;
-		d3dDevice_WARP.As(&dxgiDevice);
+		hr = d3dDevice_WARP.As(&dxgiDevice);
+		if (FAILED(hr))
+		{
+			resetState();
+			return hr;
+		}
 
-		d2dFactory1->CreateDevice(dxgiDevice.Get(), d2dDevice_WARP.ReleaseAndGetAddressOf());
+		hr = d2dFactory1->CreateDevice(dxgiDevice.Get(), d2dDevice_WARP.ReleaseAndGetAddressOf());
+		if (FAILED(hr))
+		{
+			resetState();
+			return hr;
+		}
 	}
+
+	return S_OK;
 }
 void D2DShutdown()
 {
+	d2dDevice_WARP.Reset();
+	d3dDevice_WARP.Reset();
 	dWriteFontCollection.Reset();
 	dWriteFactory1.Reset();
 	d2dFactory1.Reset();

--- a/智绘教/IdtD2DPreparation.cpp
+++ b/智绘教/IdtD2DPreparation.cpp
@@ -1,23 +1,28 @@
 ﻿#include "IdtD2DPreparation.h"
 
-CComPtr<ID2D1Factory1> d2dFactory1;
+ComPtr<ID2D1Factory1> d2dFactory1;
 
-CComPtr<IDWriteFactory1> dWriteFactory1;
-CComPtr<IDWriteFontCollection> dWriteFontCollection;
+ComPtr<IDWriteFactory1> dWriteFactory1;
+ComPtr<IDWriteFontCollection> dWriteFontCollection;
 
-CComPtr<ID3D11Device> d3dDevice_WARP;
-CComPtr<ID2D1Device> d2dDevice_WARP;
+ComPtr<ID3D11Device> d3dDevice_WARP;
+ComPtr<ID2D1Device> d2dDevice_WARP;
 
 void D2DStarup()
 {
 	// 创建 D2D1.1 工厂
-	ID2D1Factory1* tmpFactory = nullptr;
-	D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, __uuidof(ID2D1Factory1), NULL, (IID_PPV_ARGS(&tmpFactory)));
-	d2dFactory1.Attach(tmpFactory);
+	D2D1CreateFactory(
+		D2D1_FACTORY_TYPE_MULTI_THREADED,
+		__uuidof(ID2D1Factory1),
+		NULL,
+		reinterpret_cast<void**>(d2dFactory1.ReleaseAndGetAddressOf())
+	);
 
-	IDWriteFactory1* tmpWriteFactory = nullptr;
-	DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory1), reinterpret_cast<IUnknown**>(&tmpWriteFactory));
-	dWriteFactory1.Attach(tmpWriteFactory);
+	DWriteCreateFactory(
+		DWRITE_FACTORY_TYPE_SHARED,
+		__uuidof(IDWriteFactory1),
+		reinterpret_cast<IUnknown**>(dWriteFactory1.ReleaseAndGetAddressOf())
+	);
 
 	// 初始化 DC
 	{
@@ -38,20 +43,20 @@ void D2DStarup()
 			featureLevels,              // 功能级别数组
 			ARRAYSIZE(featureLevels),   // 数组大小
 			D3D11_SDK_VERSION,          // SDK 版本
-			&d3dDevice_WARP,            // 返回创建的设备
+			d3dDevice_WARP.ReleaseAndGetAddressOf(),            // 返回创建的设备
 			nullptr,                    // 返回实际的功能级别
 			nullptr                     // 返回设备上下文 (我们不需要)
 		);
 
-		CComPtr<IDXGIDevice> dxgiDevice;
-		d3dDevice_WARP.QueryInterface(&dxgiDevice);
+		ComPtr<IDXGIDevice> dxgiDevice;
+		d3dDevice_WARP.As(&dxgiDevice);
 
-		d2dFactory1->CreateDevice(dxgiDevice, &d2dDevice_WARP);
+		d2dFactory1->CreateDevice(dxgiDevice.Get(), d2dDevice_WARP.ReleaseAndGetAddressOf());
 	}
 }
 void D2DShutdown()
 {
-	dWriteFontCollection.Release();
-	dWriteFactory1.Release();
-	d2dFactory1.Release();
+	dWriteFontCollection.Reset();
+	dWriteFactory1.Reset();
+	d2dFactory1.Reset();
 }

--- a/智绘教/IdtD2DPreparation.h
+++ b/智绘教/IdtD2DPreparation.h
@@ -11,13 +11,13 @@
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
 
-extern CComPtr<ID2D1Factory1> d2dFactory1;
+extern ComPtr<ID2D1Factory1> d2dFactory1;
 
-extern CComPtr<IDWriteFactory1> dWriteFactory1;
-extern CComPtr<IDWriteFontCollection> dWriteFontCollection;
+extern ComPtr<IDWriteFactory1> dWriteFactory1;
+extern ComPtr<IDWriteFontCollection> dWriteFontCollection;
 
-extern CComPtr<ID3D11Device> d3dDevice_WARP;
-extern CComPtr<ID2D1Device> d2dDevice_WARP;
+extern ComPtr<ID3D11Device> d3dDevice_WARP;
+extern ComPtr<ID2D1Device> d2dDevice_WARP;
 
 //class IdtFontFileEnumerator : public IDWriteFontFileEnumerator
 //{

--- a/智绘教/IdtD2DPreparation.h
+++ b/智绘教/IdtD2DPreparation.h
@@ -158,5 +158,5 @@ void DxObjectSafeRelease(T** ppT)
 		*ppT = NULL;
 	}
 }
-void D2DStarup();
+HRESULT D2DStarup();
 void D2DShutdown();

--- a/智绘教/IdtMain.cpp
+++ b/智绘教/IdtMain.cpp
@@ -1117,7 +1117,12 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 
 	// 界面绘图库初始化
 	{
-		D2DStarup();
+		HRESULT hr = D2DStarup();
+		if (FAILED(hr))
+		{
+			if (IDTLogger) IDTLogger->error("[主线程][IdtMain] 界面绘图库初始化失败, hr=0x{:08X}", static_cast<unsigned int>(hr));
+			return 0;
+		}
 
 		IDTLogger->info("[主线程][IdtMain] 界面绘图库初始化完成");
 	}

--- a/智绘教/IdtMain.cpp
+++ b/智绘教/IdtMain.cpp
@@ -1170,12 +1170,12 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 
 				for (UINT32 i = 0; i < familyCount; ++i)
 				{
-					CComPtr<IDWriteFontFamily> fontFamily;
+					ComPtr<IDWriteFontFamily> fontFamily;
 					HRESULT hr = dWriteFontCollection->GetFontFamily(i, &fontFamily);
 					if (FAILED(hr)) continue;
 
 					// 获取家族名
-					CComPtr<IDWriteLocalizedStrings> familyNames;
+					ComPtr<IDWriteLocalizedStrings> familyNames;
 					hr = fontFamily->GetFamilyNames(&familyNames);
 					if (FAILED(hr)) continue;
 
@@ -1199,7 +1199,7 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 					UINT32 fontCount = fontFamily->GetFontCount();
 					for (UINT32 j = 0; j < fontCount; ++j)
 					{
-						CComPtr<IDWriteFont> font;
+						ComPtr<IDWriteFont> font;
 						hr = fontFamily->GetFont(j, &font);
 						if (FAILED(hr)) continue;
 

--- a/智绘教/IdtMain.h
+++ b/智绘教/IdtMain.h
@@ -63,7 +63,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <variant>
-#include <atlbase.h>
+#include <wrl/client.h>
 
 // 日志类
 #define SPDLOG_WCHAR_FILENAMES
@@ -94,6 +94,7 @@
 
 using namespace std;
 using namespace Gdiplus;
+using Microsoft::WRL::ComPtr;
 
 #define HiBeginDraw() BEGIN_TASK()
 #define HiEndDraw() END_TASK(); REDRAW_WINDOW()

--- a/智绘教/IdtPlug-in.cpp
+++ b/智绘教/IdtPlug-in.cpp
@@ -84,7 +84,7 @@ PptUiRoundRectWidgetClass pptUiRoundRectWidget[15], pptUiRoundRectWidgetTarget[1
 PptUiImageWidgetClass pptUiImageWidget[9], pptUiImageWidgetTarget[9];
 PptUiWordsWidgetClass pptUiWordsWidget[8], pptUiWordsWidgetTarget[8];
 
-CComPtr<ID2D1Bitmap> pptIconBitmap[6];
+ComPtr<ID2D1Bitmap> pptIconBitmap[6];
 
 void PptUiWidgetValueTransformation(float* v, float tv, float s, float e, int num = 1)
 {
@@ -1154,7 +1154,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Img = pptIconBitmap[1];
+				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Img = pptIconBitmap[1].Get();
 			}
 			{
 				pptUiWordsWidget[PptUiWordsWidgetID::BottomSide_LeftPageNum_Above].Left = PptUiWidgetValue(15, 0.1f);
@@ -1189,7 +1189,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftNextPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftNextPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftNextPage].Transparency = PptUiWidgetValue(20, 1);
-				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[2];
+				pptUiImageWidget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[2].Get();
 			}
 		}
 		// 底部右侧控件
@@ -1230,7 +1230,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Img = pptIconBitmap[1];
+				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Img = pptIconBitmap[1].Get();
 			}
 			{
 				pptUiWordsWidget[PptUiWordsWidgetID::BottomSide_RightPageNum_Above].Left = PptUiWidgetValue(15, 0.1f);
@@ -1265,7 +1265,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightNextPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightNextPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightNextPage].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[2];
+				pptUiImageWidget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[2].Get();
 			}
 		}
 
@@ -1307,7 +1307,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Img = pptIconBitmap[1];
+				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Img = pptIconBitmap[1].Get();
 			}
 			{
 				pptUiWordsWidget[PptUiWordsWidgetID::MiddleSide_LeftPageNum_Above].Left = PptUiWidgetValue(15, 0.1f);
@@ -1342,7 +1342,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Transparency = PptUiWidgetValue(20, 1);
-				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[2];
+				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[2].Get();
 			}
 		}
 		// 中部右侧控件
@@ -1383,7 +1383,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Img = pptIconBitmap[1];
+				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Img = pptIconBitmap[1].Get();
 			}
 			{
 				pptUiWordsWidget[PptUiWordsWidgetID::MiddleSide_RightPageNum_Above].Left = PptUiWidgetValue(15, 0.1f);
@@ -1418,7 +1418,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightNextPage].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightNextPage].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightNextPage].Transparency = PptUiWidgetValue(20, 1);
-				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[2];
+				pptUiImageWidget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[2].Get();
 			}
 		}
 
@@ -1460,7 +1460,7 @@ void PptUI()
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Width = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Height = PptUiWidgetValue(15, 0.1f);
 				pptUiImageWidget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Transparency = PptUiWidgetValue(25, 1);
-				pptUiImageWidget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Img = pptIconBitmap[3];
+				pptUiImageWidget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Img = pptIconBitmap[3].Get();
 			}
 		}
 
@@ -1591,7 +1591,7 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Height.v = (40) * pptComSetlist.bottomSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Transparency.v = 255;
-							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Img = pptIconBitmap[1];
+							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftPreviousPage].Img = pptIconBitmap[1].Get();
 						}
 					}
 					{
@@ -1629,8 +1629,8 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Height.v = (40) * pptComSetlist.bottomSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Transparency.v = 255;
-							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[3];
-							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[2];
+							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[3].Get();
+							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_LeftNextPage].Img = pptIconBitmap[2].Get();
 						}
 					}
 				}
@@ -1673,7 +1673,7 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Height.v = (40) * pptComSetlist.bottomSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Transparency.v = 255;
-							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Img = pptIconBitmap[1];
+							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightPreviousPage].Img = pptIconBitmap[1].Get();
 						}
 					}
 					{
@@ -1711,8 +1711,8 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Height.v = (40) * pptComSetlist.bottomSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Transparency.v = 255;
-							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[3];
-							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[2];
+							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[3].Get();
+							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_RightNextPage].Img = pptIconBitmap[2].Get();
 						}
 					}
 
@@ -1775,7 +1775,7 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Height.v = (40) * pptComSetlist.middleSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Transparency.v = 255;
-							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Img = pptIconBitmap[4];
+							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftPreviousPage].Img = pptIconBitmap[4].Get();
 						}
 					}
 					{
@@ -1813,8 +1813,8 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Height.v = (40) * pptComSetlist.middleSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Transparency.v = 255;
-							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[3];
-							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[5];
+							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[3].Get();
+							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_LeftNextPage].Img = pptIconBitmap[5].Get();
 						}
 					}
 				}
@@ -1866,7 +1866,7 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Height.v = (40) * pptComSetlist.middleSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Transparency.v = 255;
-							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Img = pptIconBitmap[4];
+							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightPreviousPage].Img = pptIconBitmap[4].Get();
 						}
 					}
 					{
@@ -1904,8 +1904,8 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Height.v = (40) * pptComSetlist.middleSideBothWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Transparency.v = 255;
-							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[3];
-							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[5];
+							if (pptCurrentSlides == -1) pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[3].Get();
+							else pptUiImageWidgetTarget[PptUiImageWidgetID::MiddleSide_RightNextPage].Img = pptIconBitmap[5].Get();
 						}
 					}
 				}
@@ -1958,7 +1958,7 @@ void PptUI()
 							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Height.v = (40) * pptComSetlist.bottomSideMiddleWidgetScale;
 							if (pptUiWidgetState == PptUiWidgetStateEnum::Close) pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Transparency.v = 0;
 							else pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Transparency.v = 255;
-							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Img = pptIconBitmap[3];
+							pptUiImageWidgetTarget[PptUiImageWidgetID::BottomSide_MiddleEndShow].Img = pptIconBitmap[3].Get();
 						}
 					}
 				}
@@ -2821,7 +2821,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -2858,7 +2858,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -2978,7 +2978,7 @@ void PptDraw()
 
 					HRESULT hr = dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3015,7 +3015,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3186,7 +3186,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3223,7 +3223,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3375,7 +3375,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3412,7 +3412,7 @@ void PptDraw()
 
 					dWriteFactory1->CreateTextFormat(
 						L"HarmonyOS Sans SC",
-						dWriteFontCollection,
+						dWriteFontCollection.Get(),
 						DWRITE_FONT_WEIGHT_NORMAL,
 						DWRITE_FONT_STYLE_NORMAL,
 						DWRITE_FONT_STRETCH_NORMAL,
@@ -3584,7 +3584,7 @@ void PptDraw()
 		}
 	}
 
-	for (int r = 0; r < (int)size(pptIconBitmap); r++) pptIconBitmap[r].Release();
+	for (int r = 0; r < (int)size(pptIconBitmap); r++) pptIconBitmap[r].Reset();
 	DCRenderTarget->Release();
 
 	for (int i = 1; i <= 5; i++)
@@ -4572,3 +4572,4 @@ bool ShortcutAssistantClass::CreateShortcut(const std::wstring& shortcutPath, co
 
 	return SUCCEEDED(hres);
 }
+

--- a/智绘教/Inkeys/UI/Bar/Bar.Format.cppm
+++ b/智绘教/Inkeys/UI/Bar/Bar.Format.cppm
@@ -26,7 +26,7 @@ struct BarFormatKey
 };
 struct CacheValue
 {
-	CComPtr<IDWriteTextFormat> pFormat;
+	ComPtr<IDWriteTextFormat> pFormat;
 	unsigned int usageCountThisFrame = 0; // 用于记录本帧的使用次数
 };
 
@@ -58,7 +58,7 @@ public:
 		{
 			// 找到了！增加本帧使用计数，并返回缓存的对象。
 			it->second.usageCountThisFrame++;
-			return it->second.pFormat;
+			return it->second.pFormat.Get();
 		}
 
 		// 3. 没找到，创建一个新的
@@ -89,7 +89,7 @@ public:
 			newValue.usageCountThisFrame = 1;
 
 			auto [inserted_it, success] = m_cache.emplace(key, newValue);
-			return inserted_it->second.pFormat;
+			return inserted_it->second.pFormat.Get();
 		}
 
 		// 创建失败，返回空指针
@@ -103,7 +103,7 @@ public:
 		{
 			if (it->second.usageCountThisFrame == 0)
 			{
-				// 本帧未使用，从 map 中擦除。CComPtr 会自动 Release。
+				// 本帧未使用，从 map 中擦除。ComPtr 会自动 Release。
 				// map::erase(iterator) 会返回下一个有效的迭代器。
 				it = m_cache.erase(it);
 			}
@@ -118,6 +118,6 @@ public:
 	void CleanAll() { m_cache.clear(); };
 
 private:
-	CComPtr<IDWriteFactory> m_pDWriteFactory;
+	ComPtr<IDWriteFactory> m_pDWriteFactory;
 	map<BarFormatKey, CacheValue> m_cache;
 };

--- a/智绘教/Inkeys/UI/Bar/Bar.Main.cpp
+++ b/智绘教/Inkeys/UI/Bar/Bar.Main.cpp
@@ -653,7 +653,12 @@ void BarUISetClass::Rendering()
 	ComPtr<ID2D1Bitmap1>					barBackgroundBitmap;
 	ComPtr<ID2D1GdiInteropRenderTarget>	barGdiInterop;
 	{
-		d2dDevice_WARP->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &barDeviceContext);
+		HRESULT hr = d2dDevice_WARP->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &barDeviceContext);
+		if (FAILED(hr))
+		{
+			if (IDTLogger) IDTLogger->error("[BarUISetClass::Rendering] CreateDeviceContext 失败, hr=0x{:08X}", static_cast<unsigned int>(hr));
+			return;
+		}
 
 		D2D1_BITMAP_PROPERTIES1 bitmapProperties =
 			D2D1::BitmapProperties1(
@@ -663,15 +668,25 @@ void BarUISetClass::Rendering()
 
 		D2D1_SIZE_U size = D2D1::SizeU(static_cast<UINT32>(barWindow.w), static_cast<UINT32>(barWindow.h));
 
-		barDeviceContext->CreateBitmap(
+		hr = barDeviceContext->CreateBitmap(
 			size,
 			nullptr,
 			0,
 			&bitmapProperties,
 			&barBackgroundBitmap
 		);
+		if (FAILED(hr))
+		{
+			if (IDTLogger) IDTLogger->error("[BarUISetClass::Rendering] CreateBitmap 失败, hr=0x{:08X}", static_cast<unsigned int>(hr));
+			return;
+		}
 
-		barDeviceContext.As(&barGdiInterop);
+		hr = barDeviceContext.As(&barGdiInterop);
+		if (FAILED(hr))
+		{
+			if (IDTLogger) IDTLogger->error("[BarUISetClass::Rendering] 获取 ID2D1GdiInteropRenderTarget 失败, hr=0x{:08X}", static_cast<unsigned int>(hr));
+			return;
+		}
 
 		barDeviceContext->SetTarget(barBackgroundBitmap.Get());
 		barDeviceContext->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
@@ -2286,16 +2301,29 @@ void BarUISetClass::Rendering()
 
 				// 设置窗口位置
 				POINT ptDst = { 0, 0 };
-				// 获取 DC
-				HDC hdc = nullptr;
-				barGdiInterop->GetDC(D2D1_DC_INITIALIZE_MODE_COPY, &hdc);
+				if (!barGdiInterop)
+				{
+					if (IDTLogger) IDTLogger->error("[BarUISetClass::Rendering] barGdiInterop 为空，跳过 GetDC");
+				}
+				else
+				{
+					// 获取 DC
+					HDC hdc = nullptr;
+					HRESULT hr = barGdiInterop->GetDC(D2D1_DC_INITIALIZE_MODE_COPY, &hdc);
+					if (FAILED(hr))
+					{
+						if (IDTLogger) IDTLogger->error("[BarUISetClass::Rendering] GetDC 失败, hr=0x{:08X}", static_cast<unsigned int>(hr));
+					}
+					else
+					{
+						ulwi.pptDst = &ptDst;
+						ulwi.hdcSrc = hdc;
+						ulwi.prcDirty = &target;
+						UpdateLayeredWindowIndirect(floating_window, &ulwi);
 
-				ulwi.pptDst = &ptDst;
-				ulwi.hdcSrc = hdc;
-				ulwi.prcDirty = &target;
-				UpdateLayeredWindowIndirect(floating_window, &ulwi);
-
-				barGdiInterop->ReleaseDC(nullptr);
+						barGdiInterop->ReleaseDC(nullptr);
+					}
+				}
 			}
 
 			barDeviceContext->EndDraw();

--- a/智绘教/Inkeys/UI/Bar/Bar.Main.cpp
+++ b/智绘教/Inkeys/UI/Bar/Bar.Main.cpp
@@ -210,7 +210,7 @@ LRESULT CALLBACK barWindowMsgCallback(HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 void BarMediaClass::LoadExImage() {}
 void BarMediaClass::LoadFormat()
 {
-	formatCache = make_unique<BarFormatCache>(dWriteFactory1);
+	formatCache = make_unique<BarFormatCache>(dWriteFactory1.Get());
 }
 
 // ====================
@@ -294,11 +294,11 @@ bool BarUIRendering::Shape(ID2D1DeviceContext* deviceContext, const BarUiShapeCl
 	// Clip
 	if (clip)
 	{
-		CComPtr<ID2D1SolidColorBrush> spFillBrush;
+		ComPtr<ID2D1SolidColorBrush> spFillBrush;
 		deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(RGB(0, 0, 0), 0.0), &spFillBrush);
 
 		deviceContext->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_COPY);
-		deviceContext->FillRoundedRectangle(&roundedRect, spFillBrush);
+		deviceContext->FillRoundedRectangle(&roundedRect, spFillBrush.Get());
 		deviceContext->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_SOURCE_OVER);
 	}
 	// 渲染到 DC
@@ -308,10 +308,10 @@ bool BarUIRendering::Shape(ID2D1DeviceContext* deviceContext, const BarUiShapeCl
 		{
 			COLORREF fill = shape.fill.value().val;
 
-			CComPtr<ID2D1SolidColorBrush> spFillBrush;
+			ComPtr<ID2D1SolidColorBrush> spFillBrush;
 			deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(fill, tarPct), &spFillBrush);
 
-			deviceContext->FillRoundedRectangle(&roundedRect, spFillBrush);
+			deviceContext->FillRoundedRectangle(&roundedRect, spFillBrush.Get());
 		}
 		// 渲染边框
 		if (shape.frame.has_value())
@@ -320,16 +320,16 @@ bool BarUIRendering::Shape(ID2D1DeviceContext* deviceContext, const BarUiShapeCl
 			double tarFramePct = tarPct;
 			if (shape.framePct.has_value()) tarFramePct = shape.framePct.value().val;
 
-			CComPtr<ID2D1SolidColorBrush> spBorderBrush;
+			ComPtr<ID2D1SolidColorBrush> spBorderBrush;
 			deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(frame, tarFramePct), &spBorderBrush);
 
 			FLOAT strokeWidth = 4.0f * static_cast<FLOAT>(tarZoom);
 			if (shape.ft.has_value())
 			{
 				strokeWidth = static_cast<FLOAT>(shape.ft.value().val * tarZoom);
-				if (strokeWidth > 0.0F) deviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush, strokeWidth);
+				if (strokeWidth > 0.0F) deviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush.Get(), strokeWidth);
 			}
-			else deviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush, strokeWidth);
+			else deviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush.Get(), strokeWidth);
 		}
 	}
 
@@ -417,11 +417,11 @@ bool BarUIRendering::Superellipse(ID2D1DeviceContext* deviceContext, const BarUi
 	vector<D2D1_BEZIER_SEGMENT> beziers = toBeziers(pts);
 	if (beziers.empty()) return false;
 
-	CComPtr<ID2D1PathGeometry> geometry;
+	ComPtr<ID2D1PathGeometry> geometry;
 	d2dFactory1->CreatePathGeometry(&geometry);
 
 	{
-		CComPtr<ID2D1GeometrySink> sink;
+		ComPtr<ID2D1GeometrySink> sink;
 		geometry->Open(&sink);
 		sink->BeginFigure(pts[0], D2D1_FIGURE_BEGIN_FILLED);
 		sink->AddBeziers(beziers.data(), static_cast<UINT32>(beziers.size()));
@@ -432,11 +432,11 @@ bool BarUIRendering::Superellipse(ID2D1DeviceContext* deviceContext, const BarUi
 	// Clip
 	if (clip)
 	{
-		CComPtr<ID2D1SolidColorBrush> spFillBrush;
+		ComPtr<ID2D1SolidColorBrush> spFillBrush;
 		deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(RGB(0, 0, 0), 0.0), &spFillBrush);
 
 		deviceContext->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_COPY);
-		deviceContext->FillGeometry(geometry, spFillBrush);
+		deviceContext->FillGeometry(geometry.Get(), spFillBrush.Get());
 		deviceContext->SetPrimitiveBlend(D2D1_PRIMITIVE_BLEND_SOURCE_OVER);
 	}
 
@@ -447,10 +447,10 @@ bool BarUIRendering::Superellipse(ID2D1DeviceContext* deviceContext, const BarUi
 		{
 			COLORREF fill = superellipse.fill.value().val;
 
-			CComPtr<ID2D1SolidColorBrush> spFillBrush;
+			ComPtr<ID2D1SolidColorBrush> spFillBrush;
 			deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(fill, tarPct), &spFillBrush);
 
-			deviceContext->FillGeometry(geometry, spFillBrush);
+			deviceContext->FillGeometry(geometry.Get(), spFillBrush.Get());
 		}
 		// 渲染边框
 		if (superellipse.frame.has_value())
@@ -459,16 +459,16 @@ bool BarUIRendering::Superellipse(ID2D1DeviceContext* deviceContext, const BarUi
 			double tarFramePct = tarPct;
 			if (superellipse.framePct.has_value()) tarFramePct = superellipse.framePct.value().val;
 
-			CComPtr<ID2D1SolidColorBrush> spBorderBrush;
+			ComPtr<ID2D1SolidColorBrush> spBorderBrush;
 			deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(frame, tarFramePct), &spBorderBrush);
 
 			FLOAT strokeWidth = 4.0f * static_cast<FLOAT>(tarZoom);
 			if (superellipse.ft.has_value())
 			{
 				strokeWidth = static_cast<FLOAT>(superellipse.ft.value().val * tarZoom);
-				if (strokeWidth > 0.0F) deviceContext->DrawGeometry(geometry, spBorderBrush, strokeWidth);
+				if (strokeWidth > 0.0F) deviceContext->DrawGeometry(geometry.Get(), spBorderBrush.Get(), strokeWidth);
 			}
-			else deviceContext->DrawGeometry(geometry, spBorderBrush, strokeWidth);
+			else deviceContext->DrawGeometry(geometry.Get(), spBorderBrush.Get(), strokeWidth);
 		}
 	}
 
@@ -492,7 +492,7 @@ bool BarUIRendering::Svg(ID2D1DeviceContext* deviceContext, BarUiSVGClass& svg, 
 	double tarPct = svg.pct.val; // 透明度
 
 	// 获取绘制缓存
-	CComPtr<ID2D1Bitmap> d2dBitmap;
+	ComPtr<ID2D1Bitmap> d2dBitmap;
 	{
 		bool needUpdate = false;
 		if (svg.cW != tarW || svg.cH != tarH) needUpdate = true;
@@ -512,7 +512,7 @@ bool BarUIRendering::Svg(ID2D1DeviceContext* deviceContext, BarUiSVGClass& svg, 
 	{
 		D2D1_RECT_F destRect = D2D1::RectF(static_cast<FLOAT>(tarX), static_cast<FLOAT>(tarY), static_cast<FLOAT>(tarX + tarW), static_cast<FLOAT>(tarY + tarH));
 		deviceContext->DrawBitmap(
-			d2dBitmap,
+				d2dBitmap.Get(),
 			destRect,								// 目标矩形
 			static_cast<FLOAT>(tarPct),				// 不透明度
 			D2D1_BITMAP_INTERPOLATION_MODE_LINEAR,
@@ -549,7 +549,7 @@ bool BarUIRendering::Word(ID2D1DeviceContext* deviceContext, const BarUiWordClas
 		/*IDWriteTextFormat* tmpTextFormat;
 		dWriteFactory1->CreateTextFormat(
 			L"HarmonyOS Sans SC",
-			dWriteFontCollection,
+			dWriteFontCollection.Get(),
 			DWRITE_FONT_WEIGHT_NORMAL,
 			DWRITE_FONT_STYLE_NORMAL,
 			DWRITE_FONT_STRETCH_NORMAL,
@@ -565,7 +565,7 @@ bool BarUIRendering::Word(ID2D1DeviceContext* deviceContext, const BarUiWordClas
 		textFormat = barUISetClass->barMedia.formatCache->GetFormat(
 			L"HarmonyOS Sans SC",
 			tarSize,
-			dWriteFontCollection,
+			dWriteFontCollection.Get(),
 			fontWeight,
 			DWRITE_FONT_STYLE_NORMAL,
 			DWRITE_FONT_STRETCH_NORMAL,
@@ -588,7 +588,7 @@ bool BarUIRendering::Word(ID2D1DeviceContext* deviceContext, const BarUiWordClas
 	{
 		COLORREF color = word.color.val;
 
-		CComPtr<ID2D1SolidColorBrush> spFillBrush;
+		ComPtr<ID2D1SolidColorBrush> spFillBrush;
 		deviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(color, tarPct), &spFillBrush);
 
 		deviceContext->DrawTextW(
@@ -596,7 +596,7 @@ bool BarUIRendering::Word(ID2D1DeviceContext* deviceContext, const BarUiWordClas
 			wcslen(tarContent.c_str()),
 			textFormat,
 			layoutRect,
-			spFillBrush,
+			spFillBrush.Get(),
 			D2D1_DRAW_TEXT_OPTIONS_CLIP
 		);
 	}
@@ -649,9 +649,9 @@ void BarUISetClass::Rendering()
 	}
 
 	// 初始化 D2D DC
-	CComPtr<ID2D1DeviceContext>				barDeviceContext;
-	CComPtr<ID2D1Bitmap1>					barBackgroundBitmap;
-	CComPtr<ID2D1GdiInteropRenderTarget>	barGdiInterop;
+	ComPtr<ID2D1DeviceContext>				barDeviceContext;
+	ComPtr<ID2D1Bitmap1>					barBackgroundBitmap;
+	ComPtr<ID2D1GdiInteropRenderTarget>	barGdiInterop;
 	{
 		d2dDevice_WARP->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &barDeviceContext);
 
@@ -671,9 +671,9 @@ void BarUISetClass::Rendering()
 			&barBackgroundBitmap
 		);
 
-		barDeviceContext->QueryInterface(__uuidof(ID2D1GdiInteropRenderTarget), (void**)&barGdiInterop);
+		barDeviceContext.As(&barGdiInterop);
 
-		barDeviceContext->SetTarget(barBackgroundBitmap);
+		barDeviceContext->SetTarget(barBackgroundBitmap.Get());
 		barDeviceContext->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
 	}
 
@@ -1867,7 +1867,7 @@ void BarUISetClass::Rendering()
 
 				// TODO 绘制纯白全透明警告用户开启 aero
 				auto obj = BarUISetWordEnum::BackgroundWarning;
-				spec.Word(barDeviceContext, *wordMap[obj], wordMap[obj]->Inherit(), DWRITE_FONT_WEIGHT_NORMAL, DWRITE_TEXT_ALIGNMENT_LEADING);
+				spec.Word(barDeviceContext.Get(), *wordMap[obj], wordMap[obj]->Inherit(), DWRITE_FONT_WEIGHT_NORMAL, DWRITE_TEXT_ALIGNMENT_LEADING);
 			}
 
 			using enum BarUiInheritEnum;
@@ -1884,97 +1884,97 @@ void BarUISetClass::Rendering()
 					// 绘制属性
 					{
 						auto obj = BarUISetShapeEnum::DrawAttributeBar;
-						spec.Shape(barDeviceContext, *shapeMap[obj], shapeMap[obj]->Inherit(Center, barButtomSet.preset[(int)BarButtomPresetEnum::Draw]->buttom), &current, true);
+						spec.Shape(barDeviceContext.Get(), *shapeMap[obj], shapeMap[obj]->Inherit(Center, barButtomSet.preset[(int)BarButtomPresetEnum::Draw]->buttom), &current, true);
 
 						// Color 区域
 						{
 							// Color 1
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect1;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect1;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 2
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect2;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect2;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 3
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect3;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect3;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 4
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect4;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect4;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 5
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect5;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect5;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 6
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect6;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect6;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 7
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect7;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect7;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 8
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect8;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect8;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 9
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect9;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect9;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 10
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect10;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect10;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 							// Color 11
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ColorSelect11;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_ColorSelect11;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Center, *shapeMap[obj1]));
 							}
 						}
 						// 画笔样式区域
@@ -1982,41 +1982,41 @@ void BarUISetClass::Rendering()
 							// 选中滑动槽
 							{
 								auto obj = BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove;
-								spec.Shape(barDeviceContext, *shapeMap[obj], shapeMap[obj]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj], shapeMap[obj]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 							}
 							// 选中
 							{
 								auto obj = BarUISetShapeEnum::DrawAttributeBar_DrawSelect;
-								spec.Shape(barDeviceContext, *shapeMap[obj], shapeMap[obj]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj], shapeMap[obj]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
 							}
 
 							// 画笔
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_Brush1;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_Brush1;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Top, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Top, *shapeMap[obj1]));
 
 								auto obj3 = BarUISetWordEnum::DrawAttributeBar_Brush1;
-								spec.Word(barDeviceContext, *wordMap[obj3], wordMap[obj3]->Inherit(ToBottom, *svgMap[obj2]));
+								spec.Word(barDeviceContext.Get(), *wordMap[obj3], wordMap[obj3]->Inherit(ToBottom, *svgMap[obj2]));
 							}
 							// 荧光笔
 							{
 								auto obj1 = BarUISetShapeEnum::DrawAttributeBar_Highlight1;
-								spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
+								spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(Left, *shapeMap[BarUISetShapeEnum::DrawAttributeBar_DrawSelectGroove]));
 
 								auto obj2 = BarUISetSvgEnum::DrawAttributeBar_Highlight1;
-								spec.Svg(barDeviceContext, *svgMap[obj2], svgMap[obj2]->Inherit(Top, *shapeMap[obj1]));
+								spec.Svg(barDeviceContext.Get(), *svgMap[obj2], svgMap[obj2]->Inherit(Top, *shapeMap[obj1]));
 
 								auto obj3 = BarUISetWordEnum::DrawAttributeBar_Highlight1;
-								spec.Word(barDeviceContext, *wordMap[obj3], wordMap[obj3]->Inherit(ToBottom, *svgMap[obj2]));
+								spec.Word(barDeviceContext.Get(), *wordMap[obj3], wordMap[obj3]->Inherit(ToBottom, *svgMap[obj2]));
 							}
 						}
 						// 粗细调节区域
 						{
 							auto obj1 = BarUISetShapeEnum::DrawAttributeBar_ThicknessSelect;
-							spec.Shape(barDeviceContext, *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
+							spec.Shape(barDeviceContext.Get(), *shapeMap[obj1], shapeMap[obj1]->Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::DrawAttributeBar]));
 
 							auto obj2 = BarUISetWordEnum::DrawAttributeBar_ThicknessDisplay;
 							wordMap[obj2]->Inherit(Right, *shapeMap[obj1]); // 提前计算依赖
@@ -2046,10 +2046,10 @@ void BarUISetClass::Rendering()
 									static_cast<FLOAT>(tarEndY) * tarZoom);
 
 								// ==== 创建圆角矩形几何 ====
-								CComPtr<ID2D1Factory> factory;
+								ComPtr<ID2D1Factory> factory;
 								barDeviceContext->GetFactory(&factory);
 
-								CComPtr<ID2D1RoundedRectangleGeometry> roundedRectGeo;
+								ComPtr<ID2D1RoundedRectangleGeometry> roundedRectGeo;
 								D2D1_ROUNDED_RECT roundedRect = {
 									tarRect,
 									static_cast<FLOAT>(tarRw) * tarZoom,
@@ -2058,15 +2058,15 @@ void BarUISetClass::Rendering()
 								factory->CreateRoundedRectangleGeometry(roundedRect, &roundedRectGeo);
 
 								// ==== 创建 Layer ====
-								CComPtr<ID2D1Layer> layer;
+								ComPtr<ID2D1Layer> layer;
 								barDeviceContext->CreateLayer(&layer);
 
 								// ==== 启用裁切层 ====
 								D2D1_LAYER_PARAMETERS layerParams = D2D1::LayerParameters();
-								layerParams.geometricMask = roundedRectGeo;
+								layerParams.geometricMask = roundedRectGeo.Get();
 								layerParams.maskAntialiasMode = D2D1_ANTIALIAS_MODE_PER_PRIMITIVE;
 
-								barDeviceContext->PushLayer(&layerParams, layer);
+								barDeviceContext->PushLayer(&layerParams, layer.Get());
 
 								// ====== 四个经过点（百分比） ======
 								auto w = tarRect.right - tarRect.left;
@@ -2126,10 +2126,10 @@ void BarUISetClass::Rendering()
 								auto beziers = catmullRomToBeziers(pts, 1.0f);
 
 								// ====== 创建 PathGeometry ======
-								CComPtr<ID2D1PathGeometry> pathGeometry;
+								ComPtr<ID2D1PathGeometry> pathGeometry;
 								factory->CreatePathGeometry(&pathGeometry);
 
-								CComPtr<ID2D1GeometrySink> sink;
+								ComPtr<ID2D1GeometrySink> sink;
 								pathGeometry->Open(&sink);
 
 								sink->BeginFigure(pts.front(), D2D1_FIGURE_BEGIN_HOLLOW);
@@ -2139,14 +2139,14 @@ void BarUISetClass::Rendering()
 								sink->Close();
 
 								// ==== 画刷 ====
-								CComPtr<ID2D1SolidColorBrush> brush;
+								ComPtr<ID2D1SolidColorBrush> brush;
 								barDeviceContext->CreateSolidColorBrush(
 									Inkeys::Color::ConvertToD2dColor(color, tarPct),
 									&brush
 								);
 
 								// ==== Stroke Style（圆头、圆角）====
-								CComPtr<ID2D1StrokeStyle> strokeStyle;
+								ComPtr<ID2D1StrokeStyle> strokeStyle;
 								D2D1_STROKE_STYLE_PROPERTIES props{};
 								props.startCap = D2D1_CAP_STYLE_ROUND;
 								props.endCap = D2D1_CAP_STYLE_ROUND;
@@ -2154,20 +2154,20 @@ void BarUISetClass::Rendering()
 								factory->CreateStrokeStyle(&props, nullptr, 0, &strokeStyle);
 
 								// ==== 绘制贝塞尔曲线（裁切生效）====
-								barDeviceContext->DrawGeometry(pathGeometry, brush, penThickness, strokeStyle);
+								barDeviceContext->DrawGeometry(pathGeometry.Get(), brush.Get(), penThickness, strokeStyle.Get());
 
 								// ==== 结束裁切 ====
 								barDeviceContext->PopLayer();
 							}
 
 							// obj2
-							spec.Word(barDeviceContext, *wordMap[obj2], wordMap[obj2]->Inherit(Right, *shapeMap[obj1]), DWRITE_FONT_WEIGHT_NORMAL, DWRITE_TEXT_ALIGNMENT_TRAILING);
+							spec.Word(barDeviceContext.Get(), *wordMap[obj2], wordMap[obj2]->Inherit(Right, *shapeMap[obj1]), DWRITE_FONT_WEIGHT_NORMAL, DWRITE_TEXT_ALIGNMENT_TRAILING);
 						}
 					}
 
 					// 主栏
 					auto obj = BarUISetShapeEnum::MainBar;
-					spec.Shape(barDeviceContext, *shapeMap[obj], shapeMap[obj]->Inherit(Center, *superellipseMap[BarUISetSuperellipseEnum::MainButton]), &current, true);
+					spec.Shape(barDeviceContext.Get(), *shapeMap[obj], shapeMap[obj]->Inherit(Center, *superellipseMap[BarUISetSuperellipseEnum::MainButton]), &current, true);
 
 					// 主栏按钮
 					for (int id = 0; id < barButtomSet.tot; id++)
@@ -2175,9 +2175,9 @@ void BarUISetClass::Rendering()
 						BarButtomClass* temp = barButtomSet.buttomlist.Get(id);
 						if (temp == nullptr) continue;
 
-						spec.Shape(barDeviceContext, temp->buttom, temp->buttom.Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::MainBar]));
-						spec.Svg(barDeviceContext, temp->icon, temp->icon.Inherit(Center, temp->buttom));
-						spec.Word(barDeviceContext, temp->name, temp->name.Inherit(Center, temp->buttom));
+						spec.Shape(barDeviceContext.Get(), temp->buttom, temp->buttom.Inherit(TopLeft, *shapeMap[BarUISetShapeEnum::MainBar]));
+						spec.Svg(barDeviceContext.Get(), temp->icon, temp->icon.Inherit(Center, temp->buttom));
+						spec.Word(barDeviceContext.Get(), temp->name, temp->name.Inherit(Center, temp->buttom));
 					}
 				}
 				{ /**/ }
@@ -2185,11 +2185,11 @@ void BarUISetClass::Rendering()
 				// 主按钮
 				{
 					auto obj = BarUISetSuperellipseEnum::MainButton;
-					spec.Superellipse(barDeviceContext, *superellipseMap[obj], superellipseMap[obj]->Inherit(), &current, true);
+					spec.Superellipse(barDeviceContext.Get(), *superellipseMap[obj], superellipseMap[obj]->Inherit(), &current, true);
 
 					{
 						auto obj = BarUISetSvgEnum::logo1;
-						spec.Svg(barDeviceContext, *svgMap[obj], svgMap[obj]->Inherit(Center, *superellipseMap[BarUISetSuperellipseEnum::MainButton]));
+						spec.Svg(barDeviceContext.Get(), *svgMap[obj], svgMap[obj]->Inherit(Center, *superellipseMap[BarUISetSuperellipseEnum::MainButton]));
 					}
 				}
 			}
@@ -2201,7 +2201,7 @@ void BarUISetClass::Rendering()
 				double tarZoom = barStyle.zoom;
 				wstring content = L"开发版本 " + editionDate + L" | 不代表最终品质 | " + fps;
 
-				CComPtr<IDWriteTextFormat> pTextFormat;
+				ComPtr<IDWriteTextFormat> pTextFormat;
 				pTextFormat = barMedia.formatCache->GetFormat(
 					L"HarmonyOS Sans SC",
 					12.0 * tarZoom,
@@ -2215,7 +2215,7 @@ void BarUISetClass::Rendering()
 				);
 
 				// 3. 创建画刷
-				CComPtr<ID2D1SolidColorBrush> pBrush;
+				ComPtr<ID2D1SolidColorBrush> pBrush;
 				barDeviceContext->CreateSolidColorBrush(
 					D2D1::ColorF(255, 255, 255, 0.5),
 					&pBrush);
@@ -2258,10 +2258,10 @@ void BarUISetClass::Rendering()
 				COLORREF frame = RGB(255, 0, 0);
 				D2D1_ROUNDED_RECT roundedRect = D2D1::RoundedRect(D2D1::RectF(target.left, target.top, target.right - 1, target.bottom - 1), 0, 0);
 
-				CComPtr<ID2D1SolidColorBrush> spBorderBrush;
+				ComPtr<ID2D1SolidColorBrush> spBorderBrush;
 				barDeviceContext->CreateSolidColorBrush(Inkeys::Color::ConvertToD2dColor(frame, 1.0), &spBorderBrush);
 
-				barDeviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush, 1.0f);
+				barDeviceContext->DrawRoundedRectangle(&roundedRect, spBorderBrush.Get(), 1.0f);
 			}
 			*/
 
@@ -2939,3 +2939,4 @@ namespace Inkeys::UI::Bar
 		}
 	}
 }
+


### PR DESCRIPTION
Replace ATL CComPtr usage with Microsoft::WRL::ComPtr across the codebase and update related COM call sites. Changes include: switching includes to <wrl/client.h>, adding using Microsoft::WRL::ComPtr, using .Get(), .As(), .Reset()/ReleaseAndGetAddressOf() where appropriate, updating factory creation calls (D2D1CreateFactory/DWriteCreateFactory) to write directly into ComPtr addresses, and fixing QueryInterface/Query patterns. Affected files include IdtD2DPreparation.*, IdtMain.*, IdtMain.h, IdtPlug-in.cpp, Bar.Format.cppm and Bar.Main.cpp (plus minor newline/cleanup changes). This modernizes smart-pointer usage, removes ATL dependency, and ensures correct COM pointer semantics when passing raw interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 更新了内部COM对象管理机制，采用改进的内存管理方法以增强代码稳定性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->