### PR TITLE
Add .coderabbit.yaml with review settings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# .coderabbit.yaml
+language: "zh-CN"
+
+reviews:
+  review_status: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 20
+    fail_commit_status: true
+    review_details: true
+    base_branches:
+      - "main"
+      - "inkeys1-final"
+      - "inkeys2-final"
+      - "canary"
+      - "staging"


### PR DESCRIPTION
Add new .coderabbit.yaml to enable CodeRabbit reviews in Chinese (zh-CN). Configures auto_review (enabled, drafts disabled, auto_incremental_review true, auto_pause_after_reviewed_commits set to 20), fail_commit_status and review_details enabled, and defines base branches (main, inkeys1-final, inkeys2-final, canary, staging).