### PR TITLE
Fix PowerShell -replace substitutions in rc update

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -170,10 +170,10 @@ jobs:
         $versionNumber = "{0},{1},{2},0" -f $semverMatch.Groups['major'].Value, $semverMatch.Groups['minor'].Value, $semverMatch.Groups['patch'].Value
 
         $rcContent = Get-Content $rcFile -Raw
-        $rcContent = $rcContent -replace '(?m)^(\s*FILEVERSION\s+).+$', "`$1$versionNumber"
-        $rcContent = $rcContent -replace '(?m)^(\s*PRODUCTVERSION\s+).+$', "`$1$versionNumber"
-        $rcContent = $rcContent -replace '(?m)^(\s*VALUE\s+"FileVersion",\s*").*(")$', "`$1$editionVersion`$2"
-        $rcContent = $rcContent -replace '(?m)^(\s*VALUE\s+"ProductVersion",\s*").*(")$', "`$1$editionVersion`$2"
+        $rcContent = $rcContent -replace '(?m)^(\s*FILEVERSION\s+).+$', ('${1}' + $versionNumber)
+        $rcContent = $rcContent -replace '(?m)^(\s*PRODUCTVERSION\s+).+$', ('${1}' + $versionNumber)
+        $rcContent = $rcContent -replace '(?m)^(\s*VALUE\s+"FileVersion",\s*").*("\r?)$', ('${1}' + $editionVersion + '${2}')
+        $rcContent = $rcContent -replace '(?m)^(\s*VALUE\s+"ProductVersion",\s*").*("\r?)$', ('${1}' + $editionVersion + '${2}')
 
         Set-Content -Path $rcFile -Value $rcContent -Encoding utf8
     


### PR DESCRIPTION
Use explicit '${n}' group references concatenated with version strings instead of backtick-escaped `$1` to avoid interpolation/escaping issues in PowerShell -replace. Also adjust the VALUE regexes to account for optional CRLF so the trailing quote is preserved across platforms. These changes ensure the FILEVERSION/PRODUCTVERSION and FileVersion/ProductVersion fields in .rc files are updated reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本说明

* **杂务**
  * 优化了构建工作流程中的版本信息处理逻辑，提高了脚本的可靠性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->