### PR TITLE
i18n: add 'Need translation' markers & snapshot

### DIFF
--- a/Inkeys/IdtI18n.cpp
+++ b/Inkeys/IdtI18n.cpp
@@ -8,6 +8,11 @@ namespace
 {
 	constexpr const wchar_t* DefaultI18nLanguage = L"zh-CN";
 
+    bool isPendingTranslationValue(const string& value)
+    {
+        return value.empty() || value.find("[[Need translation: ") != string::npos;
+    }
+
 	void stripUtf8Bom(string& jsonContent)
 	{
 		if (jsonContent.compare(0, 3, "\xEF\xBB\xBF") == 0) jsonContent = jsonContent.substr(3);
@@ -86,7 +91,7 @@ bool I18n::load(int type, wstring path, wstring lang)
 
 		for (auto& [key, value] : overlayI18n)
 		{
-			if (!value.empty()) nextI18n[key] = move(value);
+            if (!isPendingTranslationValue(value)) nextI18n[key] = move(value);
 		}
 	}
 

--- a/Inkeys/IdtI18n.cpp
+++ b/Inkeys/IdtI18n.cpp
@@ -10,7 +10,7 @@ namespace
 
     bool isPendingTranslationValue(const string& value)
     {
-        return value.empty() || value.find("[[Need translation: ") != string::npos;
+        return value.empty() || value.find("[[Need translation: ") == 0;
     }
 
 	void stripUtf8Bom(string& jsonContent)

--- a/Inkeys/IdtI18n.h
+++ b/Inkeys/IdtI18n.h
@@ -7,10 +7,10 @@
 // 1. 新增或调整翻译 key 时，请先修改 `Inkeys/src/i18n/zh-CN.jsonc`；
 //    `zh-CN` 是 schema 来源，也是运行时默认兜底语言。
 // 2. 修改完成后运行 `pwsh ./Scripts/i18n.ps1 sync`，
-//    让 `en-US.jsonc` / `zh-TW.jsonc` 同步结构，并重新生成 `Inkeys/IdtI18nKeys.g.h`。
-// 3. 非默认语言里未完成的项保留为 ""，运行时会自动回退到 `zh-CN`。
+//    让 `en-US.jsonc` / `zh-TW.jsonc` 同步结构、补上 `[[Need translation: ...]]` 标记，并更新 `Scripts/i18n.zh-CN.snapshot.jsonc` 与 `Inkeys/IdtI18nKeys.g.h`。
+// 3. 非默认语言里未完成的项使用 "" 或 `[[Need translation: ...]]` 标记，运行时会自动回退到 `zh-CN`。
 // 4. 提交前运行 `pwsh ./Scripts/i18n.ps1 check`，
-//    校验 key 集、占位符、换行数量和顺序是否一致。
+//    校验未完成翻译进度、key 集、占位符、换行数量和顺序是否一致。
 // 5. C++ 新代码请使用 `IA(I18nKey.A.B.C)` / `IW(I18nKey.A.B.C)`，
 //    不要继续手写字符串 key。
 // 6. 运行时若可能发生语言热切换，请使用 `I18n::isIdentifying(...)`，

--- a/Inkeys/IdtI18nKeys.g.h
+++ b/Inkeys/IdtI18nKeys.g.h
@@ -394,6 +394,8 @@ inline constexpr struct I18nKeyRoot
                     const char* CloseWppE = "SettingsUI/PlugIn/PPTHelper/Tentative/CloseWppE";
                     const char* AutoTakeOver = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOver";
                     const char* AutoTakeOverE = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverE";
+                    const char* AutoTakeOverOnce = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverOnce";
+                    const char* AutoTakeOverOnceE = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverOnceE";
                     const char* AutoTakeOverExpand = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverExpand";
                 } Tentative{};
             } PPTHelper{};

--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -53,8 +53,8 @@ import Inkeys.Other.Config;
 #pragma comment(lib, "netapi32.lib")
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
-wstring editionVersion = L"3.0.0-dev.20";		// 程序发布版本
-wstring editionDate = L"20260329a";				// 程序发布日期
+wstring editionVersion = L"3.0.0-dev.21";		// 程序发布版本
+wstring editionDate = L"20260401a";				// 程序发布日期
 
 wstring userId;									// 用户GUID
 wstring globalPath;								// 程序当前路径

--- a/Inkeys/Inkeys/Other/Other.Config.cppm
+++ b/Inkeys/Inkeys/Other/Other.Config.cppm
@@ -50,6 +50,7 @@ namespace Inkeys::ConfigDetail
 	GROUP(PlugIn, \
 		GROUP(PPTHelper, \
 			X(IdtAtomic<bool>, AutoTakeOver, false) \
+			X(IdtAtomic<bool>, AutoTakeOverOnce, true) \
 			X(IdtAtomic<bool>, AutoTakeOverExpand, true) \
 		) \
 	)

--- a/Inkeys/src/i18n/en-US.jsonc
+++ b/Inkeys/src/i18n/en-US.jsonc
@@ -389,9 +389,9 @@
           "N": "Experimental Options",
           "CloseWpp": "Allow closing of stuck/orphaned WPP presentation processes",
           "CloseWppE": "Requires a restart to take effect. After exiting a presentation in KingSoft WPS, the original WPP process sometimes doesn't close properly and remains stuck. This prevents the app from detecting new presentations and enabling integration. Enabling this option helps terminate these stuck processes. It is safe for your files and is recommended.",
-          "AutoTakeOver": "",
-          "AutoTakeOverE": "",
-          "AutoTakeOverExpand": ""
+          "AutoTakeOver": "[[Need translation: 接管放映批注]]",
+          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）]]",
+          "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
         }
       },
       "SuperTop":

--- a/Inkeys/src/i18n/en-US.jsonc
+++ b/Inkeys/src/i18n/en-US.jsonc
@@ -390,7 +390,9 @@
           "CloseWpp": "Allow closing of stuck/orphaned WPP presentation processes",
           "CloseWppE": "Requires a restart to take effect. After exiting a presentation in KingSoft WPS, the original WPP process sometimes doesn't close properly and remains stuck. This prevents the app from detecting new presentations and enabling integration. Enabling this option helps terminate these stuck processes. It is safe for your files and is recommended.",
           "AutoTakeOver": "[[Need translation: 接管放映批注]]",
-          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）]]",
+          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。]]",
+          "AutoTakeOverOnce": "[[Need translation: 每次放映至多接管一次]]",
+          "AutoTakeOverOnceE": "[[Need translation: 防止的确需要使用 PPT 原生批注的场景。]]",
           "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
         }
       },

--- a/Inkeys/src/i18n/zh-CN.jsonc
+++ b/Inkeys/src/i18n/zh-CN.jsonc
@@ -454,15 +454,16 @@
             "BottomSideMiddle": "底部主栏控件缩放"
           }
         },
-        "Tentative":
-        {
+        "Tentative": {
           "N": "实验选项",
 
           "CloseWpp": "允许关闭游离卡死的 WPP 演示进程",
           "CloseWppE": "重启软件生效。在WPS退出放映后原来的WPP演示进程并不会立即关闭，而是保持游离卡死状态。此时再次开始放映PPT则无法立即识别到放映进程并开启PPT联动。开启此选项将帮助关闭游离卡死的WPP放映进程，这不会对您的文件造成影响，推荐开启。",
 
           "AutoTakeOver": "接管放映批注",
-          "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）",
+          "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。",
+          "AutoTakeOverOnce": "每次放映至多接管一次",
+          "AutoTakeOverOnceE": "防止的确需要使用 PPT 原生批注的场景。",
           "AutoTakeOverExpand": "接管成功时展开主栏"
         }
       },

--- a/Inkeys/src/i18n/zh-TW.jsonc
+++ b/Inkeys/src/i18n/zh-TW.jsonc
@@ -390,7 +390,9 @@
           "CloseWpp": "允許關閉遊離卡死的 WPP 簡報處理序",
           "CloseWppE": "重啟軟體生效。在WPS退出放映後，原來的WPP簡報處理序並不會立卽關閉，而是保持遊離卡死狀態。此時再次開始放映PPT則無法立卽識別到放映處理序並開啟PPT連動。開啟此選項將幫助關閉遊離卡死的WPP放映處理序，這不會對您的檔案造成影響，推薦開啟。",
           "AutoTakeOver": "[[Need translation: 接管放映批注]]",
-          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）]]",
+          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。]]",
+          "AutoTakeOverOnce": "[[Need translation: 每次放映至多接管一次]]",
+          "AutoTakeOverOnceE": "[[Need translation: 防止的确需要使用 PPT 原生批注的场景。]]",
           "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
         }
       },

--- a/Inkeys/src/i18n/zh-TW.jsonc
+++ b/Inkeys/src/i18n/zh-TW.jsonc
@@ -389,9 +389,9 @@
           "N": "實驗性選項",
           "CloseWpp": "允許關閉遊離卡死的 WPP 簡報處理序",
           "CloseWppE": "重啟軟體生效。在WPS退出放映後，原來的WPP簡報處理序並不會立卽關閉，而是保持遊離卡死狀態。此時再次開始放映PPT則無法立卽識別到放映處理序並開啟PPT連動。開啟此選項將幫助關閉遊離卡死的WPP放映處理序，這不會對您的檔案造成影響，推薦開啟。",
-          "AutoTakeOver": "",
-          "AutoTakeOverE": "",
-          "AutoTakeOverExpand": ""
+          "AutoTakeOver": "[[Need translation: 接管放映批注]]",
+          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）]]",
+          "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
         }
       },
       "SuperTop":

--- a/Scripts/i18n.ps1
+++ b/Scripts/i18n.ps1
@@ -13,6 +13,9 @@ $I18nDir = Join-Path $RepoRoot 'Inkeys/src/i18n'
 $HeaderPath = Join-Path $RepoRoot 'Inkeys/IdtI18nKeys.g.h'
 $BaseLanguage = 'zh-CN'
 $BasePath = Join-Path $I18nDir "$BaseLanguage.jsonc"
+$BaseSnapshotPath = Join-Path $PSScriptRoot 'i18n.zh-CN.snapshot.jsonc'
+$NeedTranslationPrefix = '[[Need translation: '
+$NeedTranslationRegex = [regex]::new('^\[\[Need translation: (?<source>(?:\\.|(?!\]\]).)*)\]\]', [System.Text.RegularExpressions.RegexOptions]::Singleline)
 
 function Remove-JsoncComments {
 	param([string]$InputText)
@@ -206,18 +209,79 @@ function Test-MapContainsKey {
 	return ($Map -is [System.Collections.IDictionary]) -and $Map.Contains($Key)
 }
 
+function Escape-NeedTranslationSource {
+	param([AllowNull()][string]$Value)
+
+	if ($null -eq $Value) {
+		return ''
+	}
+
+	$escaped = $Value.Replace('\', '\\')
+	$escaped = $escaped.Replace(']]', '\]\]')
+	return $escaped
+}
+
+function Get-NeedTranslationPrefixText {
+	param([string]$BaseValue)
+
+    return "$NeedTranslationPrefix$(Escape-NeedTranslationSource -Value $BaseValue)]]"
+}
+
+function Get-NeedTranslationValue {
+	param(
+		[string]$BaseValue,
+		[string]$ExistingValue = ''
+	)
+
+	$prefixText = Get-NeedTranslationPrefixText -BaseValue $BaseValue
+	if ([string]::IsNullOrEmpty($ExistingValue)) {
+		return $prefixText
+	}
+
+	$markerMatch = $NeedTranslationRegex.Match($ExistingValue)
+	if ($markerMatch.Success) {
+		return $prefixText + $ExistingValue.Substring($markerMatch.Length)
+	}
+
+	return $prefixText + $ExistingValue
+}
+
+function Test-NeedTranslationValue {
+	param([AllowNull()][string]$Value)
+
+	if ($null -eq $Value) {
+		return $false
+	}
+
+	return $NeedTranslationRegex.IsMatch($Value)
+}
+
+function Test-CompletedTranslationValue {
+	param([AllowNull()][string]$Value)
+
+	return (-not [string]::IsNullOrEmpty($Value)) -and (-not (Test-NeedTranslationValue -Value $Value))
+}
+
 function Sync-Node {
 	param(
 		[Parameter(Mandatory = $true)]$BaseNode,
-		$TargetNode
+		$TargetNode,
+		$PreviousBaseNode = $null,
+		[bool]$HasPreviousBaseNode = $false
 	)
 
 	if ($BaseNode -is [string]) {
-		if ($TargetNode -is [string]) {
-			return $TargetNode
+		$targetValue = if ($TargetNode -is [string]) { [string]$TargetNode } else { $null }
+		if (-not ($TargetNode -is [string]) -or [string]::IsNullOrEmpty($targetValue)) {
+			return Get-NeedTranslationValue -BaseValue $BaseNode
 		}
 
-		return ''
+		$baseValueChanged = $HasPreviousBaseNode -and ($PreviousBaseNode -is [string]) -and ($PreviousBaseNode -ne $BaseNode)
+		if ($baseValueChanged) {
+			return Get-NeedTranslationValue -BaseValue $BaseNode -ExistingValue $targetValue
+		}
+
+		return $targetValue
 	}
 
 	if (-not ($BaseNode -is [System.Collections.IDictionary])) {
@@ -231,7 +295,14 @@ function Sync-Node {
 			$targetChild = $TargetNode[$key]
 		}
 
-		$result[$key] = Sync-Node -BaseNode $BaseNode[$key] -TargetNode $targetChild
+		$previousBaseChild = $null
+		$hasPreviousBaseChild = $false
+		if (Test-MapContainsKey -Map $PreviousBaseNode -Key $key) {
+			$previousBaseChild = $PreviousBaseNode[$key]
+			$hasPreviousBaseChild = $true
+		}
+
+		$result[$key] = Sync-Node -BaseNode $BaseNode[$key] -TargetNode $targetChild -PreviousBaseNode $previousBaseChild -HasPreviousBaseNode $hasPreviousBaseChild
 	}
 
 	return $result
@@ -416,6 +487,7 @@ function Compare-Language {
 
 	$missing = @($baseKeys | Where-Object { -not $targetKeySet.Contains($_) })
 	$extra = @($targetKeys | Where-Object { -not $baseKeySet.Contains($_) })
+	$unfinished = [System.Collections.Generic.List[object]]::new()
 
 	$commonKeys = @($baseKeys | Where-Object { $targetKeySet.Contains($_) })
 	$baseMap = @{}
@@ -428,11 +500,41 @@ function Compare-Language {
 		$targetMap[$entry.Key] = $entry.Value
 	}
 
+	$completedCount = 0
+	foreach ($key in $baseKeys) {
+		if (-not $targetKeySet.Contains($key)) {
+			$unfinished.Add([pscustomobject]@{
+					Key = $key
+					Reason = 'Missing'
+				})
+			continue
+		}
+
+		$targetValue = [string]$targetMap[$key]
+		if ([string]::IsNullOrEmpty($targetValue)) {
+			$unfinished.Add([pscustomobject]@{
+					Key = $key
+					Reason = 'Empty'
+				})
+			continue
+		}
+
+		if (Test-NeedTranslationValue -Value $targetValue) {
+			$unfinished.Add([pscustomobject]@{
+					Key = $key
+					Reason = 'Need translation'
+				})
+			continue
+		}
+
+		$completedCount++
+	}
+
 	$placeholderMismatch = [System.Collections.Generic.List[object]]::new()
 	$newlineMismatch = [System.Collections.Generic.List[object]]::new()
 	foreach ($key in $commonKeys) {
 		$targetValue = [string]$targetMap[$key]
-		if ([string]::IsNullOrEmpty($targetValue)) {
+		if (-not (Test-CompletedTranslationValue -Value $targetValue)) {
 			continue
 		}
 
@@ -481,9 +583,13 @@ function Compare-Language {
 		Language = $LanguageName
 		Missing = @($missing)
 		Extra = @($extra)
+		Unfinished = @($unfinished)
 		PlaceholderMismatch = @($placeholderMismatch)
 		NewlineMismatch = @($newlineMismatch)
 		OrderMismatch = $hasOrderMismatch
+		CompletedKeys = $completedCount
+		TotalKeys = $baseKeys.Count
+		CompletionRatio = if ($baseKeys.Count -eq 0) { 1.0 } else { $completedCount / $baseKeys.Count }
 	}
 }
 
@@ -496,8 +602,10 @@ function Write-CheckResult {
 	param($Result)
 
 	Write-Host "[check] $($Result.Language)"
+	Write-Host ("  Progress: {0}/{1} translated ({2:P2})" -f $Result.CompletedKeys, $Result.TotalKeys, $Result.CompletionRatio)
 
-	if ($Result.Missing.Count -eq 0 -and
+	if ($Result.Unfinished.Count -eq 0 -and
+		$Result.Missing.Count -eq 0 -and
 		$Result.Extra.Count -eq 0 -and
 		$Result.PlaceholderMismatch.Count -eq 0 -and
 		$Result.NewlineMismatch.Count -eq 0 -and
@@ -506,10 +614,10 @@ function Write-CheckResult {
 		return
 	}
 
-	if ($Result.Missing.Count -gt 0) {
-		Write-Host '  Missing keys:'
-		foreach ($key in $Result.Missing) {
-			Write-Host "    $key"
+	if ($Result.Unfinished.Count -gt 0) {
+		Write-Host '  Unfinished translations:'
+		foreach ($item in $Result.Unfinished) {
+			Write-Host "    [$($item.Reason)] $($item.Key)"
 		}
 	}
 
@@ -548,7 +656,8 @@ function Invoke-I18nCheck {
 		$result = Compare-Language -BaseRoot $base.Root -TargetRoot $target.Root -LanguageName $file.BaseName
 		Write-CheckResult -Result $result
 
-		if ($result.Missing.Count -gt 0 -or
+		if ($result.Unfinished.Count -gt 0 -or
+			$result.Missing.Count -gt 0 -or
 			$result.Extra.Count -gt 0 -or
 			$result.PlaceholderMismatch.Count -gt 0 -or
 			$result.NewlineMismatch.Count -gt 0 -or
@@ -565,6 +674,13 @@ function Invoke-I18nCheck {
 function Invoke-I18nSync {
 	$base = Load-JsoncOrdered -Path $BasePath
 	$baseHeaderLines = @(Get-HeaderCommentLines -RawText $base.RawText)
+	$previousBase = $null
+	$hasBaseSnapshot = Test-Path -LiteralPath $BaseSnapshotPath
+	if ($hasBaseSnapshot) {
+		$previousBase = Load-JsoncOrdered -Path $BaseSnapshotPath -AllowEmpty $true
+	}
+
+    $previousBaseRoot = if ($hasBaseSnapshot) { $previousBase.Root } else { $null }
 
 	foreach ($file in (Get-TargetLanguageFiles)) {
 		$target = Load-JsoncOrdered -Path $file.FullName -AllowEmpty $true
@@ -573,13 +689,15 @@ function Invoke-I18nSync {
 			$headerLines = $baseHeaderLines
 		}
 
-		$syncedRoot = Sync-Node -BaseNode $base.Root -TargetNode $target.Root
+        $syncedRoot = Sync-Node -BaseNode $base.Root -TargetNode $target.Root -PreviousBaseNode $previousBaseRoot -HasPreviousBaseNode $hasBaseSnapshot
 		Write-JsoncFile -Path $file.FullName -HeaderLines $headerLines -Root $syncedRoot
 		Write-Host "[sync] Updated $($file.Name)"
 	}
 
 	Write-KeyHeader -BaseRoot $base.Root
 	Write-Host "[sync] Updated $(Split-Path -Leaf $HeaderPath)"
+	Write-Utf8File -Path $BaseSnapshotPath -Content $base.RawText
+	Write-Host "[sync] Updated $(Split-Path -Leaf $BaseSnapshotPath)"
 
 	Invoke-I18nCheck
 }

--- a/Scripts/i18n.zh-CN.snapshot.jsonc
+++ b/Scripts/i18n.zh-CN.snapshot.jsonc
@@ -1,0 +1,583 @@
+// 你可以在此文件中使用 // 作为行注释，但块注释和尾随逗号等其他 JSONC 功能不受支持。
+// You can use // as line comments in this file, but other JSONC features such as block comments and trailing commas are not supported.
+{
+  "Language": "zh-CN",
+  "Widget":
+  {
+    "LnkName": "智绘教(屏幕批注工具)"
+  },
+  "Operate":
+  {
+    "Reset": "重置",
+    "Repair": "修复",
+    "Copy": "复制",
+    "Create": "创建"
+  },
+
+  "UI":
+  {
+    "Centre":
+    {
+      "Select": "选择",
+      "SelectClean": "选择(清空)",
+      "Pen": "画笔",
+      "Eraser": "橡皮",
+      "Options": "选项"
+    },
+    "Pen":
+    {
+
+      "Pen": "画笔",
+      "Highlighter": "荧光笔",
+
+      "Thinkness": "粗\n细",
+
+      "Write": "书写",
+      "Line": "直线",
+      "Square": "矩形"
+    },
+    "Operate":
+    {
+      "Revoke": "撤回",
+      "Recall": "超级恢复",
+      "Freeze": "定格",
+      "Pierce": "穿透"
+    }
+  },
+  "SettingsUI":
+  {
+    "N": "智绘教Inkeys 选项",
+
+    "Home":
+    {
+      "N": "主页",
+      "Prompt": "此版本为 Inkeys 3 预览版本，不代表最终品质。",
+      "Developer": "智绘教Inkeys 创始开发者",
+      "Group": "QQ 用户群",
+      "GroupE": "618720802",
+      "BilibiliChannel": "Bilibili 宣发频道",
+      "FeedBack": "问题/建议反馈"
+    },
+    "Language":
+    {
+      "N": "语言",
+
+      "UI":
+      {
+        "N": "界面语言",
+
+        "Select": "选择语言",
+        "SelectE": "Choose language | [需要重启软件]",
+
+        "Language":
+        {
+          "en-US": "English(Beta)",
+          "zh-CN": "简体中文",
+          "zh-TW": "繁體中文(Beta)"
+        },
+        "Warn": "需要重启软件才能完全生效，是否重启？"
+      }
+    },
+    "Configuration":
+    {
+      "N": "配置保存",
+
+      "Clean":
+      {
+        "N": "配置清理",
+
+        "Enable": "启用配置清理",
+        "EnableE": "软件将在启动时和保存配置时清理配置表。具体为删去多余配置项（和当前软件版本的配置项模板比较）, 这可能导致在软件降级再升级后和导入配置时会丢失部分配置项, 这些配置项将会变为默认选项。"
+      },
+      "CanvasSave":
+      {
+        "N": "画布保存",
+
+        "Enable": "启用历史画布保存",
+        "EnableE": "存储在程序目录下 ScreenShot 文件夹内，并供“超级恢复”使用历史画布。",
+
+        "SaveTime":
+        {
+          "N": "保存时长",
+          "E": "超过设定时长后，在启动时清理过期的历史画布。",
+
+          "1d": "1天",
+          "3d": "3天",
+          "5d": "5天",
+          "10d": "10天",
+          "30d": "30天",
+          "Never": "从不清理"
+        }
+      }
+    },
+    "Version":
+    {
+      "N": "软件版本",
+
+      "ManualUpdate":
+      {
+        "N": "发现软件新版本",
+
+        "ManualUpdate": "手动更新"
+      },
+      "LimitUpdate":
+      {
+        "N": "自动更新被阻止！\n\n更新的版本系统兼容性有所调整，我们阻止了您的自动更新，因为自动更新后软件可能无法启动。请查看详细信息确认您的系统环境是否符合要求，并手动下载软件并更新。需要注意是，当前通道的修复功能将暂不可用。",
+
+        "Info": "详细信息"
+      },
+      "Inkeys3Update":
+      {
+        "N": "Inkeys3 已经正式发布！\n\n您可以通过底部按钮了解更多 Inkeys3 的信息。需要注意是，当前通道的修复功能将暂不可用。",
+
+        "Download": "立即更新"
+      },
+      "VersionTip": "检测到软件架构与系统架构不符，与系统架构不适应有可能会导致软件效率降低，并影响体验。建议在本页面下方“软件修复”模块中修复软件（启用“修复时修正软件架构”选项），或在页面底端手动选择目标架构并修复。",
+
+      "Info":
+      {
+        "N": "版本信息",
+
+        "ReleaseVersion": "软件发布版本",
+        "ReleaseDate": "软件发布时间",
+        "ReleaseArch": "软件架构和系统架构",
+
+        "ReleaseTag": "软件构建模式为发布版本(RELEASE)",
+        "DebugTag": "软件构建模式为非发布调测版本(DEBUG)",
+
+        "ManualBuild": "此版本为手动构建",
+        "AutoBuild": "此版本为自动构建(CI/CD) ",
+        "CICDInfo": "自动构建详情信息"
+      },
+      "UserInfo":
+      {
+        "N": "用户信息",
+
+        "CopyUserId": "复制用户ID",
+        "UserId": "用户ID"
+      },
+      "Repair":
+      {
+        "N": "软件修复",
+
+        "RepairSoftware": "修复软件",
+        "RepairSoftwareE": "重新安装软件至所选通道的最新版本",
+
+        "RepairArch": "修复时修正软件架构"
+      },
+      "Update":
+      {
+        "N": "更新偏好",
+
+        "AutoUpate": "自动更新(静默)",
+        "ChannelTip": "正式通道(LTS) 推送最新的稳定版本, 具有较高的稳定性。（推荐）\n预览通道(Insider) 推送稳定性一般的预览版本, 且可能会被杀毒软件误报。\n早期通道(Canary) 推送 Inkeys3 早期版本, 不建议使用。",
+
+        "Channel":
+        {
+          "N": "目标更新通道",
+
+          "LTS": "正式通道(LTS)",
+          "Insider": "预览通道(Insider)",
+          "Canary": "早期通道(Canary)"
+        },
+        "Arch":
+        {
+          "N": "目标更新架构",
+          "E": "注意：和当前系统不一致的架构可能会导致软件无法启动或严重的性能问题。",
+
+          "64": "64位",
+          "32": "32位",
+          "Arm64": "Arm64"
+        }
+      }
+    },
+    "CICD":
+    {
+      "N": "自动构建详情信息",
+
+      "Repository": "构建仓库",
+      "Branch": "构建分支",
+      "Submitter": "构建提交者",
+      "BuildTime": "构建时间",
+      "BuildSystem": "构建系统",
+      "BuildSystemVersion": "构建系统版本",
+      "RunnerImageSystem": "运行器镜像系统",
+      "RunnerImageVersion": "运行器镜像版本",
+      "MSBuildVersion": "MSBuild 版本"
+    },
+
+    // ---
+
+    "Regular":
+    {
+      "N": "常规",
+
+      "StartUp":
+      {
+        "N": "开机自启和启动行为",
+
+        "AutoStart": "开机自动启动",
+        "AutoStartE": "设置当前用户账户开机时启动 智绘教Inkeys。",
+
+        "Link":
+        {
+          "N": "创建桌面快捷方式",
+          "E": "自动修正名称和创建快捷方式，请点击“更多选项”。",
+
+          "More": "更多选项"
+        }
+      },
+      "Appearance":
+      {
+        "N": "外观样式",
+
+        "Theme":
+        {
+          "N": "主题",
+          "E": "选择“推荐皮肤”将会根据官方推荐皮肤自动更换。",
+
+          "Skip1": "推荐皮肤",
+          "Skip2": "默认皮肤",
+          "Skip3": "极简时钟",
+          "Skip4": "马年迎新"
+        },
+        "SettingUIScale":
+        {
+          "N": "选项界面 UI 缩放",
+          "E": "[需要重启软件]缩放比例高将会占用大量内存空间。",
+
+          "Ind": "{:.2f} 倍缩放"
+        }
+      },
+      "Behavior":
+      {
+        "N": "其他行为",
+
+        "TopWindow":
+        {
+          "N": "置顶间隔",
+          "E": "在非绘制模式下将按此间隔置顶窗口，落笔时暂停置顶窗口。更短的间隔可以更少地排除其他软件的窗口的干扰，但会占用更多的CPU资源。如果其他软件其他软件的窗口持续干扰，建议使用插件-超级置顶。",
+
+          "100ms": "非常短(100ms)",
+          "500ms": "短(500ms)",
+          "1s": "较短(1s)",
+          "3s": "中等(3s)",
+          "5s": "较长(5s)",
+          "10s": "长(10s)",
+          "30s": "非常长(30s)"
+        },
+
+        "RightClickClose": "右键点击主图标关闭程序",
+        "RightClickCloseE": "将会弹出一个确认弹框。",
+        "DrawingRetract": "画笔绘制时收起主栏",
+        "ErasingRetract": "橡皮擦除时收起主栏",
+        "DraggingRetract": "拖动主栏时收起主栏",
+        "CheckingRetract": "点击时收起主栏",
+        "CheckingRetractE": "仅在选择模式或穿透下，点击非主栏区域时生效。"
+      },
+      "Tentative":
+      {
+        "N": "实验选项",
+
+        "AvoidFulScreen": "避免全屏显示",
+        "AvoidFulScreenE": "[需要重启软件]软件在非绘制模式下或穿透模式下将不会保持全屏显示。这可以保证拥有自动隐藏熟悉的任务栏可以正常升起，可能可以降低置顶窗口失败的概率，还可能可以改善任务栏无法被触摸的问题。",
+
+        "SafeMode":
+        {
+          "N": "教学安全选项",
+          "E": "软件发生崩溃错误时所执行的操作。（启动过程发生错误依旧会引发提示）",
+
+          "Mode1": "弹窗提示并重启软件",
+          "Mode2": "静默重启软件",
+          "Mode3": "交由系统崩溃过滤器处理",
+          "Mode4": "直接关闭软件"
+        }
+      }
+    },
+    "Draw":
+    {
+      "N": "绘制",
+
+      "Effect":
+      {
+        "N": "绘图效果优化",
+
+        "Device":
+        {
+          "N": "绘图设备",
+          "E": "我们将根据不同设备类型优化使用体验。",
+
+          "Touch": "触控屏幕",
+          "MousePen": "鼠标、手写笔或数位板"
+        }
+      },
+      "AIDraw":
+      {
+        "N": "智能绘图",
+
+        "PenUp": "抬笔拉直直线",
+        "PenUpE": "现阶段只推荐在教学一体机上使用。",
+        "PenStay": "停留拉直直线",
+        "PenStayE": "绘制直线完成后按住一秒，直线将被拉直。",
+
+        "EndpointAdsorption": "端点吸附",
+        "EndpointAdsorptionE": "直线和矩形的端点将会在抬笔时吸附。"
+      },
+      "DrawBehavior":
+      {
+        "N": "绘制行为",
+
+        "SoomthWriting": "抬笔平滑笔迹"
+      },
+      "RubberThickness":
+      {
+        "N": "橡皮粗细",
+
+        "Calc":
+        {
+          "N": "橡皮粗细计算方式",
+          "E": "如果特定设备不支持当前选项，软件会继续尝试下一个粗细计算方式。",
+
+          "Mode1": "固定粗细",
+          "Mode2": "笔速粗细",
+          "Mode3": "压感粗细"
+        }
+      },
+      "Tentative":
+      {
+        "N": "实验选项",
+
+        "HideCursor": "绘制时隐藏触控光标(BETA)",
+        "HideCursorE": "阻止触控光标（白色圆点）在画布上显示。但是当鼠标和触控笔信号出现时, 则会恢复显示鼠标光标/笔光标。"
+      }
+    },
+    "Performance":
+    {
+      "N": "性能",
+
+      "DrawMode":
+      {
+        "N": "绘图性能",
+
+        "Prepare":
+        {
+          "N": "落笔预备",
+          "E": "越大则越多手指落下时更快开始绘制，但会占用更多内存。",
+
+          "Ind": "{:d} 指"
+        },
+
+        "SuperDraw": "极限性能绘图(BETA)",
+        "SuperDrawE": "仅适用于拥有强大 CPU 的设备（重要！否则将引起卡顿）。 在绘制模式下取消画布渲染间隔，额外性能开销都仅在绘制中产生（即非选择状态下）。 如果发现绘制延迟高、不跟手，请关闭此选项。"
+        }
+     },
+    "Preset":
+    {
+      "N": "预设",
+
+      "Memory":
+      {
+        "N": "记忆",
+
+        "Thickness": "记忆绘制粗细",
+        "ThicknessE": "在启动软件时使画笔与荧光笔的粗细和退出时一致。",
+        "Color": "记忆绘制颜色",
+        "ColorE": "在启动软件时使画笔与荧光笔的颜色和退出时一致。"
+      },
+      "Preset":
+      {
+        "N": "预设（仅在未开启对应绘制记忆时生效）",
+
+        "AutoThickness": "自适应绘制粗细",
+        "AutoThicknessE": "在启动时，根据屏幕分辨率和物理尺寸自动设定推荐的绘制粗细。（画笔当前为{}px；荧光笔当前为{}px）",
+
+        "Pen": "预设画笔粗细",
+        "PenInd": "{} px",
+        "Highlighter": "预设荧光笔粗细",
+        "HighlighterInd": "{} px"
+      }
+    },
+    "PlugIn":
+    {
+      "N": "插件",
+
+      "PPTHelper":
+      {
+        "N": "PPT演示助手 3 Lite",
+        "E": "在幻灯片演示时提供演示控制按钮和画笔控制按钮。每页拥有独立画板，可以让笔迹固定在页面上。不影响原有功能和外接设备的使用，支持 Microsoft PowerPoint 2007 和 Kingsoft WPS 2013 及以上版本。",
+
+        "VersionError": "版本号未知（插件发生错误）",
+        "Solve": "解决方案",
+        "Sync": "同步调节",
+        "Reset": "重置",
+
+        "Tip": "使用插件时需要保证智绘教Inkeys的程序权限和PPT程序是一致的才能正确识别。如果依然存在问题，可以参考解决方案。",
+        "Warn": "检测到您的PowerPoint/WPS已经设置为始终以管理员身份打开，这意味着程序需要以管理员身份运行才能识别到放映进程并开启PPT联动。如果您不希望放映软件始终以管理员身份运行，可以参考解决方案。",
+        "Error": "插件加载发生错误，可能是因为未安装 .NET Framework 4.x 或全局 COM 环境发生异常。\n错误代码",
+
+        "BasicLogic":
+        {
+          "N": "基础逻辑",
+
+          "InkFixation": "墨迹固定在对应页面上",
+          "InkFixationE": "每个PPT页面都将拥有各自独立的画布，并可以实现类似PPT自带画笔的效果。翻页不会清空之前页面所绘制的墨迹，可以返回之前的页面继续绘制。",
+          "LoadPage": "显示加载页面",
+          "LoadPageE": "包含插件标识和小提示等，每个 PPT 仅显示一次。"
+        },
+        "WidgetDisplay":
+        {
+          "N": "控件显示",
+
+          "BottomBoth": "显示底部两侧控件",
+          "MiddleBoth": "显示中部两侧控件",
+          "BottomMiddle": "显示底部主栏控件"
+        },
+        "WidgetPosition":
+        {
+          "N": "控件位置",
+
+          "Reset": "重置控件位置",
+          "Remember": "记忆控件位置"
+        },
+        "WidgetScale":
+        {
+          "N": "控件缩放",
+          "Ind": "{:.2f} 倍缩放",
+
+          "Page":
+          {
+            "BottomSideBoth": "底部两侧控件缩放",
+            "MiddleSideBoth": "中部两侧控件缩放"
+          },
+          "State":
+          {
+            "BottomSideMiddle": "底部主栏控件缩放"
+          }
+        },
+        "Tentative":
+        {
+          "N": "实验选项",
+
+          "CloseWpp": "允许关闭游离卡死的 WPP 演示进程",
+          "CloseWppE": "重启软件生效。在WPS退出放映后原来的WPP演示进程并不会立即关闭，而是保持游离卡死状态。此时再次开始放映PPT则无法立即识别到放映进程并开启PPT联动。开启此选项将帮助关闭游离卡死的WPP放映进程，这不会对您的文件造成影响，推荐开启。",
+
+          "AutoTakeOver": "接管放映批注",
+          "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）",
+          "AutoTakeOverExpand": "接管成功时展开主栏"
+        }
+      },
+      "SuperTop":
+      {
+        "N": "超级置顶",
+        "E": "使用UiAccess技术在其他常规软件之上显示软件窗口，亦或是在任务栏、Alt+Tab、屏幕键盘、锁屏界面等上方显示软件窗口。仅支持Windows8及以上系统。",
+
+        "Warn": "超级置顶插件处于 BETA 阶段，可能遇到不稳定的问题。\n软件在启动时会通过再运行自身的方式进行提权，提权成功后再运行新的软件实例。\n该过程可能失败，导致错误地启动拥有管理员权限的软件，可能会影响 PPT 联动。\n过程中会弹出 UAC 确认弹窗，请点击确认或关闭 UAC 提示（不推荐）。\n过程中可能被杀毒软件误报，这是正常现象。",
+
+        "Capability":
+        {
+          "N": "基础能力",
+
+          "SuperTop": "超级置顶",
+          "SuperTopE1": "软件将三段式启动进行置顶，小概率出现问题导致置顶失败。重启后生效。\n（当前已经超级置顶）",
+          "SuperTopE2": "软件将三段式启动进行置顶，小概率出现问题导致置顶失败。重启后生效。\n（当前未超级置顶）",
+
+          "Indicator": "超级置顶指示器",
+          "IndicatorE": "软件成功被超级置顶时，在主图标右上角显示一个大头针。"
+        }
+      },
+      "DesktopDrawpadBlocker":
+      {
+        "N": "同类软件悬浮窗拦截助手 3 Lite",
+        "E": "在教学一体机上，一些白板软件的桌面悬浮窗画笔功能不能直接关闭，桌面上会出现多家画笔工具的悬浮窗。这容易导致老师混用不同的工具导致无法继续批注，这严重影响了教学效率，于是 DesktopDrawpadBlocker 应运而生。"
+      },
+      "LnkHelper":
+      {
+        "N": "快捷方式保障助手",
+        "E": "在程序启动时确保已经创建的智绘教Inkeys快捷方式是有效的。因为程序更新会修改文件名称，这会导致快捷方式失效。可选的，如果桌面没有智绘教Inkeys的快捷方式，则创建一个。",
+
+        "Capability":
+        {
+          "N": "基础能力",
+
+          "FixLnk": "修正桌面快捷方式指向和名称",
+          "FixLnkE": "软件启动时将修正桌面已经存在的软件快捷方式。软件自动更新后可能会改变文件名，推荐开启。"
+        },
+        "Expansion":
+        {
+          "N": "拓展选项",
+
+          "CreateLnk": "创建桌面快捷方式",
+          "CreateLnkE": "当桌面不存在软件的快捷方式时，则创建一个。"
+        }
+      }
+    },
+    "Component":
+    {
+      "N": "组件"
+    },
+    "HotKey":
+    {
+      "N": "快捷键",
+      "E": "全局快捷键：\nCtrl + Win + Alt 切换选择 / 绘制模式\n\n绘制模式下：\nCtrl + Q 定格\nCtrl + E 穿透\nCtrl + Z 撤回 / 超级恢复\n\n其余快捷键和自定义快捷键正在测试，敬请期待"
+    },
+
+    // ---
+
+    "Community":
+    {
+      "N": "社区名片"
+    },
+    "Sponsor":
+    {
+      "N": "赞助我们"
+    },
+
+    // ---
+
+    "RestartSoftware":
+    {
+      "N": "重启软件"
+    },
+    "ExitSoftware":
+    {
+      "N": "关闭软件"
+    },
+    "DebugSoftware":
+    {
+      "N": "调试软件"
+    },
+
+    // ---
+
+    "Update":
+    {
+      "Check": "检查更新",
+
+      "Channel":
+      {
+        "LTS": "正式通道",
+        "Insider": "预览通道",
+        "Dev": "开发通道",
+        "Canary": "早期通道",
+        "Other": "其他通道"
+      },
+
+      "NotStarted": "新版本检测未启动",
+      "ObtainInformation": "获取新版本信息中",
+      "InformationFail": "下载版本信息失败",
+      "InformationDamage": "下载版本信息损坏",
+      "InformationUnStandardized": "下载版本信息不符合规范",
+      "Downloading": "新版本正极速下载中（线路{}）",
+      "DownloadFail": "下载最新版本软件失败",
+      "DownloadDamage": "下载最新版本软件损坏",
+      "Restart": "重启软件更新到最新版本",
+      "Latest": "软件已经是最新版本",
+      "Newer": "软件相对最新版本更新",
+      "New": "发现软件新版本",
+
+      "Repair": "尝试修复",
+      "ManualDownload": "手动下载最新版本",
+      "UpdateNow": "更新到最新版本"
+    }
+  }
+}

--- a/Scripts/i18n.zh-CN.snapshot.jsonc
+++ b/Scripts/i18n.zh-CN.snapshot.jsonc
@@ -454,15 +454,16 @@
             "BottomSideMiddle": "底部主栏控件缩放"
           }
         },
-        "Tentative":
-        {
+        "Tentative": {
           "N": "实验选项",
 
           "CloseWpp": "允许关闭游离卡死的 WPP 演示进程",
           "CloseWppE": "重启软件生效。在WPS退出放映后原来的WPP演示进程并不会立即关闭，而是保持游离卡死状态。此时再次开始放映PPT则无法立即识别到放映进程并开启PPT联动。开启此选项将帮助关闭游离卡死的WPP放映进程，这不会对您的文件造成影响，推荐开启。",
 
           "AutoTakeOver": "接管放映批注",
-          "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。（每次放映至多接管一次）",
+          "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。",
+          "AutoTakeOverOnce": "每次放映至多接管一次",
+          "AutoTakeOverOnceE": "防止的确需要使用 PPT 原生批注的场景。",
           "AutoTakeOverExpand": "接管成功时展开主栏"
         }
       },


### PR DESCRIPTION
Introduce explicit [[Need translation: ...]] markers and snapshot support to improve translation workflow. Add runtime check (isPendingTranslationValue) to ignore pending-marker values so they fall back to zh-CN; update IdtI18n.h docs to describe the new marker and snapshot workflow. Enhance Scripts/i18n.ps1 to generate/maintain markers, preserve existing translated suffixes, compute translation progress, report unfinished keys, and write a zh-CN snapshot file; Sync-Node and checking logic updated accordingly. Populate AutoTakeOver keys in en-US/zh-TW with marker text and add Scripts/i18n.zh-CN.snapshot.jsonc snapshot. Also bump editionVersion/editionDate in IdtMain.cpp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加“待翻译”标记识别与处理，未完成的翻译不会被应用。
  * 新增 PPT 演示助手选项：“每次放映至多接管一次”。

* **文档**
  * 完善国际化维护说明，明确同步与未完成翻译校验流程。
  * 新增简体中文界面文案快照，丰富本地化资源。

* **Chores**
  * 更新版本信息至 3.0.0-dev.21。
  * 补充/占位多语言文案以标记待翻译项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->