### PR TITLE
Add AutoTakeOverOnce setting and version bump

### DIFF
--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -53,7 +53,7 @@ import Inkeys.Other.Config;
 #pragma comment(lib, "netapi32.lib")
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
-wstring editionVersion = L"3.0.0-dev.22";		// 程序发布版本
+wstring editionVersion = L"3.0.0-dev.23";		// 程序发布版本
 wstring editionDate = L"20260401a";				// 程序发布日期
 
 wstring userId;									// 用户GUID

--- a/Inkeys/IdtPlug-in.cpp
+++ b/Inkeys/IdtPlug-in.cpp
@@ -2392,7 +2392,7 @@ void PptInfo()
 			if (toolType == 1 && StartPptTakeoverAnnotation(toolType))
 			{
 				ExitPptSlideShowAnnotationTool();
-				pptTakeoverConsumedInCurrentShow = true;
+				if(config.PlugIn.PPTHelper.AutoTakeOverOnce) pptTakeoverConsumedInCurrentShow = true;
 
 				if (config.PlugIn.PPTHelper.AutoTakeOverExpand)
 				{

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -6464,7 +6464,7 @@ void SettingMain(stop_token sT)
 								PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 								PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
 								PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(255, 255, 255, 0));
-								ImGui::BeginChild("PPT演示助手#7", { 750.0f * settingGlobalScale,165.0f * settingGlobalScale }, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+								ImGui::BeginChild("PPT演示助手#7", { 750.0f * settingGlobalScale,240.0f * settingGlobalScale }, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
 								{
 									ImGui::SetCursorPos({ 0.0f * settingGlobalScale, 0.0f * settingGlobalScale });
@@ -6516,6 +6516,60 @@ void SettingMain(stop_token sT)
 										if (Inkeys::config.PlugIn.PPTHelper.AutoTakeOver != value)
 										{
 											Inkeys::config.PlugIn.PPTHelper.AutoTakeOver = value;
+											Inkeys::config.Write();
+										}
+									}
+
+									{
+										if (PushStyleColorNum >= 0) ImGui::PopStyleColor(PushStyleColorNum), PushStyleColorNum = 0;
+										if (PushStyleVarNum >= 0) ImGui::PopStyleVar(PushStyleVarNum), PushStyleVarNum = 0;
+										while (PushFontNum) PushFontNum--, ImGui::PopFont();
+									}
+									ImGui::EndChild();
+								}
+								{
+									ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5.0f * settingGlobalScale);
+									PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+									PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.0f);
+									PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(251, 251, 251, 255));
+									ImGui::BeginChild("AutoTakeOverOnce", { 750.0f * settingGlobalScale,70.0f * settingGlobalScale }, true, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+									float cursosPosY = 0;
+									{
+										ImGui::SetCursorPos({ 20.0f * settingGlobalScale, cursosPosY + 20.0f * settingGlobalScale });
+										ImFontMain->Scale = 0.6f, PushFontNum++, ImGui::PushFont(ImFontMain);
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
+										ImGui::TextUnformatted(IA(I18nKey.SettingsUI.PlugIn.PPTHelper.Tentative.AutoTakeOverOnce).c_str());
+									}
+									{
+										ImGui::SetCursorPos({ 20.0f * settingGlobalScale, ImGui::GetCursorPosY() });
+										ImFontMain->Scale = 0.5f, PushFontNum++, ImGui::PushFont(ImFontMain);
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(120, 120, 120, 255));
+										ImGui::TextUnformatted(IA(I18nKey.SettingsUI.PlugIn.PPTHelper.Tentative.AutoTakeOverOnceE).c_str());
+									}
+									{
+										bool value = Inkeys::config.PlugIn.PPTHelper.AutoTakeOverOnce;
+
+										ImGui::SetCursorPos({ 690.0f * settingGlobalScale, cursosPosY + 20.0f * settingGlobalScale });
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 6));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(0, 0, 0, 15));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 95, 184, 255));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(0, 95, 184, 230));
+										if (!value)
+										{
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 155));
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_BorderShadow, IM_COL32(0, 0, 0, 155));
+										}
+										else
+										{
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_BorderShadow, IM_COL32(0, 95, 184, 255));
+										}
+										ImGui::Toggle("##AutoTakeOverOnce", &value, config);
+
+										if (Inkeys::config.PlugIn.PPTHelper.AutoTakeOverOnce != value)
+										{
+											Inkeys::config.PlugIn.PPTHelper.AutoTakeOverOnce = value;
 											Inkeys::config.Write();
 										}
 									}

--- a/Scripts/i18n.ps1
+++ b/Scripts/i18n.ps1
@@ -391,6 +391,9 @@ function Get-SyncHeaderLines {
         return $BaseHeaderLines
     }
 
+    if (($HeaderLines -join "`n") -ne ($BaseHeaderLines -join "`n")) {
+        return $BaseHeaderLines
+    }
     return $HeaderLines
 }
 


### PR DESCRIPTION
Introduce a new AutoTakeOverOnce option for the PPT helper and wire it into behavior and the settings UI. Changes: bump editionVersion to 3.0.0-dev.23 (Inkeys/IdtMain.cpp); only mark pptTakeoverConsumedInCurrentShow when AutoTakeOverOnce is enabled (Inkeys/IdtPlug-in.cpp); expand the PPT settings panel and add a new AutoTakeOverOnce child with its toggle and persistence (Inkeys/Inkeys/UI/Setting/Setting.cpp); and make the i18n header-sync fall back to base headers when mismatched (Scripts/i18n.ps1). This lets users opt into one-time automatic takeover and prevents unconditional consumption of the takeover flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加PowerPoint演示助手自动接管选项，用户可在设置中启用或禁用此功能。

* **Bug修复**
  * 优化PowerPoint接管功能的触发逻辑，确保仅在启用自动接管选项时记录接管状态。

* **其他**
  * 版本更新至 3.0.0-dev.23。
  * 改进国际化脚本的翻译文件同步机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->