### PR TITLE
Add long-press page-turn option

### DIFF
--- a/Inkeys/IdtI18nKeys.g.h
+++ b/Inkeys/IdtI18nKeys.g.h
@@ -397,6 +397,7 @@ inline constexpr struct I18nKeyRoot
                     const char* AutoTakeOverOnce = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverOnce";
                     const char* AutoTakeOverOnceE = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverOnceE";
                     const char* AutoTakeOverExpand = "SettingsUI/PlugIn/PPTHelper/Tentative/AutoTakeOverExpand";
+                    const char* EnablePageButtonLongPress = "SettingsUI/PlugIn/PPTHelper/Tentative/EnablePageButtonLongPress";
                 } Tentative{};
             } PPTHelper{};
             struct Node__SettingsUI__PlugIn__SuperTop

--- a/Inkeys/IdtPlug-in.cpp
+++ b/Inkeys/IdtPlug-in.cpp
@@ -3713,20 +3713,23 @@ void PptInteract()
 						PreviousPptSlides();
 						pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-						SetCapture(ppt_window);
-						std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-						while (1)
+						if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 						{
-							if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage])) break;
-							if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+							SetCapture(ppt_window);
+							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+							while (1)
 							{
-								PreviousPptSlides();
-								pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
-							}
+								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage])) break;
+								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								{
+									PreviousPptSlides();
+									pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
+								}
 
-							this_thread::sleep_for(chrono::milliseconds(15));
+								this_thread::sleep_for(chrono::milliseconds(15));
+							}
+							PptUiReleaseMouseCapture();
 						}
-						PptUiReleaseMouseCapture();
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(250, 250, 250, 160);
 						hiex::flushmessage_win32(EM_MOUSE, ppt_window);
@@ -3772,35 +3775,38 @@ void PptInteract()
 							NextPptSlides(temp_currentpage);
 							pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-							SetCapture(ppt_window);
-							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-							while (1)
+							if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 							{
-								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage])) break;
-
-								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								SetCapture(ppt_window);
+								std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+								while (1)
 								{
-									temp_currentpage = PptInfoState.CurrentPage;
-									if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
-									{
-										PptUiReleaseMouseCapture();
-										if (CheckEndShow.Check())
-										{
-											ChangeStateModeToSelection();
-											EndPptShow();
-										}
-										break;
-									}
-									else if (temp_currentpage != -1)
-									{
-										NextPptSlides(temp_currentpage);
-										pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
-									}
-								}
+									if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage])) break;
 
-								this_thread::sleep_for(chrono::milliseconds(15));
+									if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+									{
+										temp_currentpage = PptInfoState.CurrentPage;
+										if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
+										{
+											PptUiReleaseMouseCapture();
+											if (CheckEndShow.Check())
+											{
+												ChangeStateModeToSelection();
+												EndPptShow();
+											}
+											break;
+										}
+										else if (temp_currentpage != -1)
+										{
+											NextPptSlides(temp_currentpage);
+											pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
+										}
+									}
+
+									this_thread::sleep_for(chrono::milliseconds(15));
+								}
+								PptUiReleaseMouseCapture();
 							}
-							PptUiReleaseMouseCapture();
 						}
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::BottomSide_LeftPageWidget_NextPage].FillColor.v = RGBA(250, 250, 250, 160);
@@ -3851,20 +3857,23 @@ void PptInteract()
 						PreviousPptSlides();
 						pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-						SetCapture(ppt_window);
-						std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-						while (1)
+						if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 						{
-							if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage])) break;
-							if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+							SetCapture(ppt_window);
+							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+							while (1)
 							{
-								PreviousPptSlides();
-								pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
-							}
+								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage])) break;
+								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								{
+									PreviousPptSlides();
+									pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
+								}
 
-							this_thread::sleep_for(chrono::milliseconds(15));
+								this_thread::sleep_for(chrono::milliseconds(15));
+							}
+							PptUiReleaseMouseCapture();
 						}
-						PptUiReleaseMouseCapture();
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(250, 250, 250, 160);
 						hiex::flushmessage_win32(EM_MOUSE, ppt_window);
@@ -3910,35 +3919,38 @@ void PptInteract()
 							NextPptSlides(temp_currentpage);
 							pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-							SetCapture(ppt_window);
-							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-							while (1)
+							if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 							{
-								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage])) break;
-
-								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								SetCapture(ppt_window);
+								std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+								while (1)
 								{
-									temp_currentpage = PptInfoState.CurrentPage;
-									if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
-									{
-										PptUiReleaseMouseCapture();
-										if (CheckEndShow.Check())
-										{
-											ChangeStateModeToSelection();
-											EndPptShow();
-										}
-										break;
-									}
-									else if (temp_currentpage != -1)
-									{
-										NextPptSlides(temp_currentpage);
-										pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
-									}
-								}
+									if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage])) break;
 
-								this_thread::sleep_for(chrono::milliseconds(15));
+									if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+									{
+										temp_currentpage = PptInfoState.CurrentPage;
+										if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
+										{
+											PptUiReleaseMouseCapture();
+											if (CheckEndShow.Check())
+											{
+												ChangeStateModeToSelection();
+												EndPptShow();
+											}
+											break;
+										}
+										else if (temp_currentpage != -1)
+										{
+											NextPptSlides(temp_currentpage);
+											pptUiRoundRectWidget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
+										}
+									}
+
+									this_thread::sleep_for(chrono::milliseconds(15));
+								}
+								PptUiReleaseMouseCapture();
 							}
-							PptUiReleaseMouseCapture();
 						}
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::BottomSide_RightPageWidget_NextPage].FillColor.v = RGBA(250, 250, 250, 160);
@@ -3991,20 +4003,23 @@ void PptInteract()
 						PreviousPptSlides();
 						pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-						SetCapture(ppt_window);
-						std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-						while (1)
+						if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 						{
-							if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage])) break;
-							if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+							SetCapture(ppt_window);
+							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+							while (1)
 							{
-								PreviousPptSlides();
-								pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
-							}
+								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage])) break;
+								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								{
+									PreviousPptSlides();
+									pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
+								}
 
-							this_thread::sleep_for(chrono::milliseconds(15));
+								this_thread::sleep_for(chrono::milliseconds(15));
+							}
+							PptUiReleaseMouseCapture();
 						}
-						PptUiReleaseMouseCapture();
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_PreviousPage].FillColor.v = RGBA(250, 250, 250, 160);
 						hiex::flushmessage_win32(EM_MOUSE, ppt_window);
@@ -4050,35 +4065,38 @@ void PptInteract()
 							NextPptSlides(temp_currentpage);
 							pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-							SetCapture(ppt_window);
-							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-							while (1)
+							if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 							{
-								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage])) break;
-
-								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								SetCapture(ppt_window);
+								std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+								while (1)
 								{
-									temp_currentpage = PptInfoState.CurrentPage;
-									if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
-									{
-										PptUiReleaseMouseCapture();
-										if (CheckEndShow.Check())
-										{
-											ChangeStateModeToSelection();
-											EndPptShow();
-										}
-										break;
-									}
-									else if (temp_currentpage != -1)
-									{
-										NextPptSlides(temp_currentpage);
-										pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
-									}
-								}
+									if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage])) break;
 
-								this_thread::sleep_for(chrono::milliseconds(15));
+									if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+									{
+										temp_currentpage = PptInfoState.CurrentPage;
+										if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
+										{
+											PptUiReleaseMouseCapture();
+											if (CheckEndShow.Check())
+											{
+												ChangeStateModeToSelection();
+												EndPptShow();
+											}
+											break;
+										}
+										else if (temp_currentpage != -1)
+										{
+											NextPptSlides(temp_currentpage);
+											pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
+										}
+									}
+
+									this_thread::sleep_for(chrono::milliseconds(15));
+								}
+								PptUiReleaseMouseCapture();
 							}
-							PptUiReleaseMouseCapture();
 						}
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::MiddleSide_LeftPageWidget_NextPage].FillColor.v = RGBA(250, 250, 250, 160);
@@ -4132,20 +4150,23 @@ void PptInteract()
 						PreviousPptSlides();
 						pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-						SetCapture(ppt_window);
-						std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-						while (1)
+						if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 						{
-							if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage])) break;
-							if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+							SetCapture(ppt_window);
+							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+							while (1)
 							{
-								PreviousPptSlides();
-								pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
-							}
+								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage])) break;
+								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								{
+									PreviousPptSlides();
+									pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(200, 200, 200, 255);
+								}
 
-							this_thread::sleep_for(chrono::milliseconds(15));
+								this_thread::sleep_for(chrono::milliseconds(15));
+							}
+							PptUiReleaseMouseCapture();
 						}
-						PptUiReleaseMouseCapture();
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_PreviousPage].FillColor.v = RGBA(250, 250, 250, 160);
 						hiex::flushmessage_win32(EM_MOUSE, ppt_window);
@@ -4191,35 +4212,38 @@ void PptInteract()
 							NextPptSlides(temp_currentpage);
 							pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
 
-							SetCapture(ppt_window);
-							std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
-							while (1)
+							if (config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress)
 							{
-								if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage])) break;
-
-								if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+								SetCapture(ppt_window);
+								std::chrono::high_resolution_clock::time_point KeyboardInteractionManipulated = std::chrono::high_resolution_clock::now();
+								while (1)
 								{
-									temp_currentpage = PptInfoState.CurrentPage;
-									if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
-									{
-										PptUiReleaseMouseCapture();
-										if (CheckEndShow.Check())
-										{
-											ChangeStateModeToSelection();
-											EndPptShow();
-										}
-										break;
-									}
-									else if (temp_currentpage != -1)
-									{
-										NextPptSlides(temp_currentpage);
-										pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
-									}
-								}
+									if (!PptUiIsLeftButtonPressedInRoundRect(m, pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage])) break;
 
-								this_thread::sleep_for(chrono::milliseconds(15));
+									if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - KeyboardInteractionManipulated).count() >= 400)
+									{
+										temp_currentpage = PptInfoState.CurrentPage;
+										if (temp_currentpage == -1 && stateMode.StateModeSelect != StateModeSelectEnum::IdtSelection && penetrate.select == false)
+										{
+											PptUiReleaseMouseCapture();
+											if (CheckEndShow.Check())
+											{
+												ChangeStateModeToSelection();
+												EndPptShow();
+											}
+											break;
+										}
+										else if (temp_currentpage != -1)
+										{
+											NextPptSlides(temp_currentpage);
+											pptUiRoundRectWidget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage].FillColor.v = RGBA(200, 200, 200, 255);
+										}
+									}
+
+									this_thread::sleep_for(chrono::milliseconds(15));
+								}
+								PptUiReleaseMouseCapture();
 							}
-							PptUiReleaseMouseCapture();
 						}
 
 						pptUiRoundRectWidgetTarget[PptUiRoundRectWidgetID::MiddleSide_RightPageWidget_NextPage].FillColor.v = RGBA(250, 250, 250, 160);

--- a/Inkeys/Inkeys/Other/Other.Config.cppm
+++ b/Inkeys/Inkeys/Other/Other.Config.cppm
@@ -52,6 +52,9 @@ namespace Inkeys::ConfigDetail
 			X(IdtAtomic<bool>, AutoTakeOver, false) \
 			X(IdtAtomic<bool>, AutoTakeOverOnce, true) \
 			X(IdtAtomic<bool>, AutoTakeOverExpand, true) \
+			GROUP(Tentative, \
+				X(IdtAtomic<bool>, EnablePageButtonLongPress, false) \
+			) \
 		) \
 	)
 

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -6473,7 +6473,7 @@ void SettingMain(stop_token sT)
 								PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 								PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
 								PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(255, 255, 255, 0));
-								ImGui::BeginChild("PPT演示助手#7", { 750.0f * settingGlobalScale,230.0f * settingGlobalScale }, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+								ImGui::BeginChild("PPT演示助手#7", { 750.0f * settingGlobalScale,300.0f * settingGlobalScale }, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
 								{
 									ImGui::SetCursorPos({ 0.0f * settingGlobalScale, 0.0f * settingGlobalScale });
@@ -6615,6 +6615,55 @@ void SettingMain(stop_token sT)
 										if (Inkeys::config.PlugIn.PPTHelper.AutoTakeOverExpand != value)
 										{
 											Inkeys::config.PlugIn.PPTHelper.AutoTakeOverExpand = value;
+											Inkeys::config.Write();
+										}
+									}
+
+									{
+										if (PushStyleColorNum >= 0) ImGui::PopStyleColor(PushStyleColorNum), PushStyleColorNum = 0;
+										if (PushStyleVarNum >= 0) ImGui::PopStyleVar(PushStyleVarNum), PushStyleVarNum = 0;
+										while (PushFontNum) PushFontNum--, ImGui::PopFont();
+									}
+									ImGui::EndChild();
+								}
+
+								{
+									ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5.0f * settingGlobalScale);
+									PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+									PushStyleVarNum++, ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 4.0f);
+									PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(251, 251, 251, 255));
+									ImGui::BeginChild("启用翻页按钮长按翻页", { 750.0f * settingGlobalScale,60.0f * settingGlobalScale }, true, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+									float cursosPosY = 0;
+									{
+										ImGui::SetCursorPos({ 20.0f * settingGlobalScale, cursosPosY + 22.0f * settingGlobalScale });
+										ImFontMain->Scale = 0.6f, PushFontNum++, ImGui::PushFont(ImFontMain);
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
+										ImGui::TextUnformatted(IA(I18nKey.SettingsUI.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress).c_str());
+									}
+									{
+										bool value = Inkeys::config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress;
+
+										ImGui::SetCursorPos({ 690.0f * settingGlobalScale, cursosPosY + 20.0f * settingGlobalScale });
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 6));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(0, 0, 0, 15));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 95, 184, 255));
+										PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(0, 95, 184, 230));
+										if (!value)
+										{
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 155));
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_BorderShadow, IM_COL32(0, 0, 0, 155));
+										}
+										else
+										{
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
+											PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_BorderShadow, IM_COL32(0, 95, 184, 255));
+										}
+										ImGui::Toggle("##启用翻页按钮长按翻页", &value, config);
+
+										if (Inkeys::config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress != value)
+										{
+											Inkeys::config.PlugIn.PPTHelper.Tentative.EnablePageButtonLongPress = value;
 											Inkeys::config.Write();
 										}
 									}

--- a/Inkeys/src/i18n/en-US.jsonc
+++ b/Inkeys/src/i18n/en-US.jsonc
@@ -389,11 +389,12 @@
           "N": "Experimental Options",
           "CloseWpp": "Allow closing of stuck/orphaned WPP presentation processes",
           "CloseWppE": "Requires a restart to take effect. After exiting a presentation in KingSoft WPS, the original WPP process sometimes doesn't close properly and remains stuck. This prevents the app from detecting new presentations and enabling integration. Enabling this option helps terminate these stuck processes. It is safe for your files and is recommended.",
-          "AutoTakeOver": "[[Need translation: 接管放映批注]]",
-          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。]]",
-          "AutoTakeOverOnce": "[[Need translation: 每次放映至多接管一次]]",
-          "AutoTakeOverOnceE": "[[Need translation: 防止的确需要使用 PPT 原生批注的场景。]]",
-          "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
+          "AutoTakeOver": "Take over presentation ink annotations",
+          "AutoTakeOverE": "When PPT native annotations are detected, switch to the app's drawing mode and turn off PPT native annotations.",
+          "AutoTakeOverOnce": "Take over at most once per presentation",
+          "AutoTakeOverOnceE": "Avoid interfering when PPT native annotations are intentionally needed.",
+          "AutoTakeOverExpand": "Expand the main bar after takeover succeeds",
+          "EnablePageButtonLongPress": "Enable long-press page turning buttons"
         }
       },
       "SuperTop":

--- a/Inkeys/src/i18n/zh-CN.jsonc
+++ b/Inkeys/src/i18n/zh-CN.jsonc
@@ -393,7 +393,8 @@
           "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。",
           "AutoTakeOverOnce": "每次放映至多接管一次",
           "AutoTakeOverOnceE": "防止的确需要使用 PPT 原生批注的场景。",
-          "AutoTakeOverExpand": "接管成功时展开主栏"
+          "AutoTakeOverExpand": "接管成功时展开主栏",
+          "EnablePageButtonLongPress": "启用翻页按钮长按翻页"
         }
       },
       "SuperTop":

--- a/Inkeys/src/i18n/zh-TW.jsonc
+++ b/Inkeys/src/i18n/zh-TW.jsonc
@@ -156,7 +156,7 @@
         "Arch":
         {
           "N": "目標更新架構",
-          "E": "注意：與現在系統不一致的架構可能會導致軟體無法啟動或嚴重效能問題。",
+          "E": "註意：與現在系統不一致的架構可能會導致軟體無法啟動或嚴重效能問題。",
           "64": "64位",
           "32": "32位",
           "Arm64": "Arm64"
@@ -266,17 +266,17 @@
       "AIDraw":
       {
         "N": "智慧繪圖",
-        "PenUp": "抬筆拉直直線",
+        "PenUp": "擡筆拉直直線",
         "PenUpE": "目前僅推薦於教學一體機使用。",
         "PenStay": "停留拉直直線",
         "PenStayE": "繪製直線完成後按住一秒，直線將被拉直。",
         "EndpointAdsorption": "端點吸附",
-        "EndpointAdsorptionE": "直線和矩形端點將在抬筆時吸附。"
+        "EndpointAdsorptionE": "直線和矩形端點將在擡筆時吸附。"
       },
       "DrawBehavior":
       {
         "N": "繪圖行為",
-        "SoomthWriting": "抬筆平滑筆跡"
+        "SoomthWriting": "擡筆平滑筆跡"
       },
       "RubberThickness":
       {
@@ -346,7 +346,7 @@
         "Solve": "解決方案",
         "Sync": "同步調節",
         "Reset": "重設",
-        "Tip": "使用插件時需要確保智繪教Inkeys的程式權限和PPT程式是一致的才能正確識別。如果依然存在問題，可以參考解決方案。",
+        "Tip": "使用插件時需要確保智绘教Inkeys的程式權限和PPT程式是一致的才能正確識別。如果依然存在問題，可以參考解決方案。",
         "Warn": "偵測到您的PowerPoint/WPS已經設定為一律以系統管理員身分開啟，這意味著程式需要以系統管理員身分執行才能識別到放映處理序並開啟PPT連動。如果您不希望放映軟體一律以系統管理員身分執行，可以參考解決方案。",
         "Error": "外掛程式載入發生錯誤，可能是因為未安裝 .NET Framework 4.x 或全域 COM 環境發生異常。\n錯誤代碼",
         "BasicLogic":
@@ -359,29 +359,29 @@
         },
         "WidgetDisplay":
         {
-          "N": "控制項顯示",
-          "BottomBoth": "顯示底部兩側控制項",
-          "MiddleBoth": "顯示中部兩側控制項",
-          "BottomMiddle": "顯示底部主欄控制項"
+          "N": "控製項顯示",
+          "BottomBoth": "顯示底部兩側控製項",
+          "MiddleBoth": "顯示中部兩側控製項",
+          "BottomMiddle": "顯示底部主欄控製項"
         },
         "WidgetPosition":
         {
-          "N": "控制項位置",
-          "Reset": "重設控制項位置",
-          "Remember": "記憶控制項位置"
+          "N": "控製項位置",
+          "Reset": "重設控製項位置",
+          "Remember": "記憶控製項位置"
         },
         "WidgetScale":
         {
-          "N": "控制項縮放",
+          "N": "控製項縮放",
           "Ind": "{:.2f} 倍縮放",
           "Page":
           {
-            "BottomSideBoth": "底部兩側控制項縮放",
-            "MiddleSideBoth": "中部兩側控制項縮放"
+            "BottomSideBoth": "底部兩側控製項縮放",
+            "MiddleSideBoth": "中部兩側控製項縮放"
           },
           "State":
           {
-            "BottomSideMiddle": "底部主欄控制項縮放"
+            "BottomSideMiddle": "底部主欄控製項縮放"
           }
         },
         "Tentative":
@@ -389,11 +389,12 @@
           "N": "實驗性選項",
           "CloseWpp": "允許關閉遊離卡死的 WPP 簡報處理序",
           "CloseWppE": "重啟軟體生效。在WPS退出放映後，原來的WPP簡報處理序並不會立卽關閉，而是保持遊離卡死狀態。此時再次開始放映PPT則無法立卽識別到放映處理序並開啟PPT連動。開啟此選項將幫助關閉遊離卡死的WPP放映處理序，這不會對您的檔案造成影響，推薦開啟。",
-          "AutoTakeOver": "[[Need translation: 接管放映批注]]",
-          "AutoTakeOverE": "[[Need translation: 在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。]]",
-          "AutoTakeOverOnce": "[[Need translation: 每次放映至多接管一次]]",
-          "AutoTakeOverOnceE": "[[Need translation: 防止的确需要使用 PPT 原生批注的场景。]]",
-          "AutoTakeOverExpand": "[[Need translation: 接管成功时展开主栏]]"
+          "AutoTakeOver": "接管放映批註",
+          "AutoTakeOverE": "在識別到開啟了 PPT 原生批註後，將開啟軟體內繪製模式，並關閉 PPT 原生批註。",
+          "AutoTakeOverOnce": "每次放映至多接管一次",
+          "AutoTakeOverOnceE": "避免確實需要使用 PPT 原生批註的情境。",
+          "AutoTakeOverExpand": "接管成功時展開主欄",
+          "EnablePageButtonLongPress": "啟用翻頁按鈕長按翻頁"
         }
       },
       "SuperTop":
@@ -414,7 +415,7 @@
       "DesktopDrawpadBlocker":
       {
         "N": "同類軟體懸浮視窗攔截小幫手 3 Lite",
-        "E": "在教學一體機上，一些白板軟體的桌面懸浮窗畫筆功能不能直接關閉，桌面會出現多家畫筆工具的懸浮窗。這容易導致老師混用不同的工具而無法繼續批注，嚴重影響了教學效率，於是 DesktopDrawpadBlocker 應運而生。"
+        "E": "在教學一體機上，一些白板軟體的桌面懸浮窗畫筆功能不能直接關閉，桌面會出現多家畫筆工具的懸浮窗。這容易導致老師混用不同的工具而無法繼續批註，嚴重影響了教學效率，於是 DesktopDrawpadBlocker 應運而生。"
       },
       "LnkHelper":
       {

--- a/Scripts/i18n.zh-CN.snapshot.jsonc
+++ b/Scripts/i18n.zh-CN.snapshot.jsonc
@@ -393,7 +393,8 @@
           "AutoTakeOverE": "在识别到开启了 PPT 原生批注后，将打开软件内绘制模式，并关闭 PPT 原生批注。",
           "AutoTakeOverOnce": "每次放映至多接管一次",
           "AutoTakeOverOnceE": "防止的确需要使用 PPT 原生批注的场景。",
-          "AutoTakeOverExpand": "接管成功时展开主栏"
+          "AutoTakeOverExpand": "接管成功时展开主栏",
+          "EnablePageButtonLongPress": "启用翻页按钮长按翻页"
         }
       },
       "SuperTop":


### PR DESCRIPTION
Introduce a new Tentative setting EnablePageButtonLongPress that enables repeating page turns while holding the page buttons. Updates: add config field and generated i18n key, add UI toggle (and expand settings child height), and wire PptInteract to check the flag and handle mouse capture/release and long-press looping correctly. Also add English/Chinese translations and update i18n snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在 PPT 演示助手的实验功能中新增长按翻页按钮选项，用户现可在设置中启用翻页按钮的长按翻页功能（默认关闭）
  * 更新多语言界面文本支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->