### PR TITLE
Handle update channel and reset installer on change

### DIFF
--- a/Inkeys/IdtConfiguration.cpp
+++ b/Inkeys/IdtConfiguration.cpp
@@ -71,6 +71,7 @@ bool UnOccupyFile(HANDLE* hFile)
 }
 
 SetListStruct setlist;
+shared_mutex setlistUpdateMutex;
 Json::Value setlistVal;
 bool ReadSetting()
 {
@@ -209,13 +210,16 @@ bool ReadSetting()
 		{
 			if (setlistVal["UpdateSetting"].isMember("EnableAutoUpdate") && setlistVal["UpdateSetting"]["EnableAutoUpdate"].isBool())
 				setlist.enableAutoUpdate = setlistVal["UpdateSetting"]["EnableAutoUpdate"].asBool();
-			if (setlistVal["UpdateSetting"].isMember("UpdateChannel") && setlistVal["UpdateSetting"]["UpdateChannel"].isString())
-				setlist.UpdateChannel = setlistVal["UpdateSetting"]["UpdateChannel"].asString();
-			if (setlistVal["UpdateSetting"].isMember("UpdateArchitecture") && setlistVal["UpdateSetting"]["UpdateArchitecture"].isString())
 			{
-				setlist.updateArchitecture = setlistVal["UpdateSetting"]["UpdateArchitecture"].asString();
-				if (setlist.updateArchitecture != "win32" && setlist.updateArchitecture != "win64" && setlist.updateArchitecture != "arm64")
-					setlist.updateArchitecture = "win32";
+				unique_lock<shared_mutex> lock(setlistUpdateMutex);
+				if (setlistVal["UpdateSetting"].isMember("UpdateChannel") && setlistVal["UpdateSetting"]["UpdateChannel"].isString())
+					setlist.UpdateChannel = setlistVal["UpdateSetting"]["UpdateChannel"].asString();
+				if (setlistVal["UpdateSetting"].isMember("UpdateArchitecture") && setlistVal["UpdateSetting"]["UpdateArchitecture"].isString())
+				{
+					setlist.updateArchitecture = setlistVal["UpdateSetting"]["UpdateArchitecture"].asString();
+					if (setlist.updateArchitecture != "win32" && setlist.updateArchitecture != "win64" && setlist.updateArchitecture != "arm64")
+						setlist.updateArchitecture = "win32";
+				}
 			}
 		}
 
@@ -414,6 +418,13 @@ bool ReadSettingMini()
 bool WriteSetting()
 {
 	if (setlist.configurationSetting.enable) setlistVal.clear();
+	string updateChannel;
+	string updateArchitecture;
+	{
+		shared_lock<shared_mutex> lock(setlistUpdateMutex);
+		updateChannel = setlist.UpdateChannel;
+		updateArchitecture = setlist.updateArchitecture;
+	}
 	{
 		{
 			setlistVal["ConfigurationSetting"]["Enable"] = Json::Value(setlist.configurationSetting.enable);
@@ -469,8 +480,8 @@ bool WriteSetting()
 
 		{
 			setlistVal["UpdateSetting"]["EnableAutoUpdate"] = Json::Value(setlist.enableAutoUpdate);
-			setlistVal["UpdateSetting"]["UpdateChannel"] = Json::Value(setlist.UpdateChannel);
-			setlistVal["UpdateSetting"]["UpdateArchitecture"] = Json::Value(setlist.updateArchitecture);
+			setlistVal["UpdateSetting"]["UpdateChannel"] = Json::Value(updateChannel);
+			setlistVal["UpdateSetting"]["UpdateArchitecture"] = Json::Value(updateArchitecture);
 		}
 		{
 			setlistVal["BasicInfo"]["UserID"] = Json::Value(utf16ToUtf8(userId));

--- a/Inkeys/IdtConfiguration.h
+++ b/Inkeys/IdtConfiguration.h
@@ -162,6 +162,7 @@ struct SetListStruct
 	} Experimental;
 };
 extern SetListStruct setlist;
+extern shared_mutex setlistUpdateMutex;
 bool ReadSetting();
 bool ReadSettingMini();
 bool WriteSetting();

--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -54,7 +54,7 @@ import Inkeys.Other.Config;
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
 wstring editionVersion = L"3.0.0-dev.39";		// 程序发布版本
-wstring editionDate = L"20260501a";				// 程序发布日期
+wstring editionDate = L"20260301a";				// 程序发布日期
 
 wstring userId;									// 用户GUID
 wstring globalPath;								// 程序当前路径
@@ -1110,8 +1110,8 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 			windowsEdition = to_wstring(windowsVersion.majorVersion) + L"." + to_wstring(windowsVersion.minorVersion) + L"." + to_wstring(windowsVersion.buildNumber);
 		}
 
-	#ifdef IDT_RELEASE
 		thread(AutomaticUpdate).detach();
+	#ifdef IDT_RELEASE
 	#endif
 	}
 

--- a/Inkeys/Inkeys/Net/Net.Update.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.cpp
@@ -17,6 +17,26 @@ import Inkeys.Conv.Text;
 bool mandatoryUpdate; // 强制更新符号
 bool inconsistentArchitecture;
 AutomaticUpdateStateEnum AutomaticUpdateState;
+namespace
+{
+	struct UpdateTargetSnapshot
+	{
+		string channel;
+		string architecture;
+	};
+
+	UpdateTargetSnapshot GetUpdateTargetSnapshot()
+	{
+		shared_lock<shared_mutex> lock(setlistUpdateMutex);
+		return { setlist.UpdateChannel, setlist.updateArchitecture };
+	}
+
+	void SetUpdateChannelSnapshot(const string& channel)
+	{
+		unique_lock<shared_mutex> lock(setlistUpdateMutex);
+		setlist.UpdateChannel = channel;
+	}
+}
 wstring get_domain_name(wstring url) {
 	wregex pattern(L"([a-zA-z]+://[^/]+)");
 	wsmatch match;
@@ -37,9 +57,10 @@ wstring convertToHttp(const wstring& url)
 string GetRefererInfo()
 {
 	string ret;
+	UpdateTargetSnapshot updateTarget = GetUpdateTargetSnapshot();
 	ret += utf16ToUtf8(editionDate) + ",";
 	ret += utf16ToUtf8(programArchitecture) + ",";
-	ret += setlist.UpdateChannel + ",";
+	ret += updateTarget.channel + ",";
 	ret += setlist.enableAutoUpdate ? "true," : "false,";
 	ret += utf16ToUtf8(windowsEdition);
 	return ret;
@@ -314,7 +335,8 @@ void AutomaticUpdate()
 	bool against = false;
 	int updateTimes = 0;
 
-	string updateArch = setlist.updateArchitecture;
+	UpdateTargetSnapshot updateTarget = GetUpdateTargetSnapshot();
+	string updateArch = updateTarget.architecture;
 
 	EditionInfoClass editionInfo;
 	using enum AutomaticUpdateStateEnum;
@@ -327,12 +349,13 @@ updateStart:
 		state = true;
 		against = false;
 
-		updateArch = setlist.updateArchitecture;
+		updateTarget = GetUpdateTargetSnapshot();
+		updateArch = updateTarget.architecture;
 
 		//获取最新版本信息
 		if (state)
 		{
-			editionInfo = GetEditionInfo(setlist.UpdateChannel, updateArch);
+			editionInfo = GetEditionInfo(updateTarget.channel, updateArch);
 
 			if (editionInfo.errorCode != 200)
 			{
@@ -341,9 +364,9 @@ updateStart:
 				else if (editionInfo.errorCode == 2) AutomaticUpdateState = UpdateInformationDamage;
 				else AutomaticUpdateState = UpdateInformationUnStandardized;
 			}
-			else if (setlist.UpdateChannel != editionInfo.channel)
+			else if (updateTarget.channel != editionInfo.channel)
 			{
-				setlist.UpdateChannel = editionInfo.channel;
+				SetUpdateChannelSnapshot(editionInfo.channel);
 				WriteSetting();
 			}
 		}
@@ -440,7 +463,8 @@ updateStart:
 
 					if (AutomaticUpdateState == UpdateRestart)
 					{
-						if (setlist.UpdateChannel != editionInfo.channel || setlist.updateArchitecture != updateArch)
+						UpdateTargetSnapshot currentUpdateTarget = GetUpdateTargetSnapshot();
+						if (currentUpdateTarget.channel != editionInfo.channel || currentUpdateTarget.architecture != updateArch)
 						{
 							if (_waccess((globalPath + L"installer").c_str(), 0) == 0)
 							{

--- a/Inkeys/Inkeys/Net/Net.Update.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.cpp
@@ -271,6 +271,7 @@ AutomaticUpdateStateEnum DownloadNewProgram(DownloadNewProgramStateClass* state,
 				root["edition"] = Json::Value(utf16ToUtf8(editionInfo.editionDate));
 				root["path"] = Json::Value("installer\\new_procedure_" + utf16ToUtf8(timestamp) + ".exe");
 				root["representation"] = Json::Value("new_procedure_" + utf16ToUtf8(timestamp) + ".exe");
+				root["channel"] = Json::Value(editionInfo.channel);
 
 				root["hash"]["md5"] = Json::Value(editionInfo.hash_md5);
 				root["hash"]["sha256"] = Json::Value(editionInfo.hash_sha256);
@@ -355,7 +356,7 @@ updateStart:
 			{
 				wstring tedition, tpath;
 				string thash_md5, thash_sha256;
-				string tarch;
+				string tchannel, tarch;
 
 				Json::Reader reader;
 				Json::Value root;
@@ -381,7 +382,9 @@ updateStart:
 					}
 					else fileDamage = true;
 
-					// 架构确定
+					// 通道和架构确定
+					if (root.isMember("channel")) tchannel = root["channel"].asString();
+					else fileDamage = true;
 					if (root.isMember("arch")) tarch = root["arch"].asString();
 					else fileDamage = true;
 				}
@@ -401,7 +404,7 @@ updateStart:
 						delete myWrapper;
 					}
 
-					if (tedition == editionInfo.editionDate && _waccess((globalPath + tpath).c_str(), 0) == 0 && hash_md5 == thash_md5 && hash_sha256 == thash_sha256 && updateArch == tarch)
+					if (tedition == editionInfo.editionDate && _waccess((globalPath + tpath).c_str(), 0) == 0 && hash_md5 == thash_md5 && hash_sha256 == thash_sha256 && editionInfo.channel == tchannel && updateArch == tarch)
 					{
 						if (!setlist.enableAutoUpdate)
 						{
@@ -427,6 +430,7 @@ updateStart:
 
 				against = true;
 				bool hasUpdateNew = false;
+				bool updateTargetChanged = false;
 				for (int i = 0; i < editionInfo.path_size; i++)
 				{
 					downloadLine = i + 1;
@@ -436,6 +440,18 @@ updateStart:
 
 					if (AutomaticUpdateState == UpdateRestart)
 					{
+						if (setlist.UpdateChannel != editionInfo.channel || setlist.updateArchitecture != updateArch)
+						{
+							if (_waccess((globalPath + L"installer").c_str(), 0) == 0)
+							{
+								error_code ec;
+								filesystem::remove_all(globalPath + L"installer", ec);
+							}
+
+							updateTargetChanged = true;
+							break;
+						}
+
 						against = false;
 
 						if (mandatoryUpdate)
@@ -458,6 +474,11 @@ updateStart:
 					}
 				}
 
+				if (updateTargetChanged)
+				{
+					AutomaticUpdateState = UpdateObtainInformation;
+					continue;
+				}
 				if (hasUpdateNew) continue;
 			}
 		}

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -221,6 +221,26 @@ void SettingWindowBegin()
 
 void SettingMain(stop_token sT)
 {
+	auto GetUpdateChannel = []()
+		{
+			shared_lock<shared_mutex> lock(setlistUpdateMutex);
+			return setlist.UpdateChannel;
+		};
+	auto SetUpdateChannel = [](const string& channel)
+		{
+			unique_lock<shared_mutex> lock(setlistUpdateMutex);
+			setlist.UpdateChannel = channel;
+		};
+	auto GetUpdateArchitecture = []()
+		{
+			shared_lock<shared_mutex> lock(setlistUpdateMutex);
+			return setlist.updateArchitecture;
+		};
+	auto SetUpdateArchitecture = [](const string& architecture)
+		{
+			unique_lock<shared_mutex> lock(setlistUpdateMutex);
+			setlist.updateArchitecture = architecture;
+		};
 	auto ClearUpdateRestartInstaller = []()
 		{
 			error_code ec;
@@ -2507,9 +2527,9 @@ void SettingMain(stop_token sT)
 								{
 									if (EnableFixWithChangeArchitecture)
 									{
-										if (targetArchitecture == L"win64") setlist.updateArchitecture = "win64";
-										else if (targetArchitecture == L"arm64") setlist.updateArchitecture = "arm64";
-										else setlist.updateArchitecture = "win32";
+										if (targetArchitecture == L"win64") SetUpdateArchitecture("win64");
+										else if (targetArchitecture == L"arm64") SetUpdateArchitecture("arm64");
+										else SetUpdateArchitecture("win32");
 										WriteSetting();
 									}
 
@@ -2725,8 +2745,9 @@ void SettingMain(stop_token sT)
 								vec.emplace_back(_strdup((IA(I18nKey.SettingsUI.Version.Update.Channel.Insider)).c_str()));
 								vec.emplace_back(_strdup((IA(I18nKey.SettingsUI.Version.Update.Channel.Canary)).c_str()));
 
-								if (setlist.UpdateChannel == "Insider") UpdateChannelMode = 1;
-								else if (setlist.UpdateChannel == "Canary") UpdateChannelMode = 2;
+								string updateChannel = GetUpdateChannel();
+								if (updateChannel == "Insider") UpdateChannelMode = 1;
+								else if (updateChannel == "Canary") UpdateChannelMode = 2;
 								else UpdateChannelMode = 0;
 
 								{
@@ -2745,13 +2766,15 @@ void SettingMain(stop_token sT)
 										if (ImGui::Selectable(vec[i], is_selected))
 										{
 											UpdateChannelMode = i;
-											if ((UpdateChannelMode == 0 && setlist.UpdateChannel != "LTS") ||
-												(UpdateChannelMode == 1 && setlist.UpdateChannel != "Insider") ||
-												(UpdateChannelMode == 2 && setlist.UpdateChannel != "Canary"))
+											if ((UpdateChannelMode == 0 && updateChannel != "LTS") ||
+												(UpdateChannelMode == 1 && updateChannel != "Insider") ||
+												(UpdateChannelMode == 2 && updateChannel != "Canary"))
 											{
-												if (UpdateChannelMode == 1) setlist.UpdateChannel = "Insider";
-												else if (UpdateChannelMode == 2) setlist.UpdateChannel = "Canary";
-												else setlist.UpdateChannel = "LTS";
+												string selectedUpdateChannel;
+												if (UpdateChannelMode == 1) selectedUpdateChannel = "Insider";
+												else if (UpdateChannelMode == 2) selectedUpdateChannel = "Canary";
+												else selectedUpdateChannel = "LTS";
+												SetUpdateChannel(selectedUpdateChannel);
 
 												WriteSetting();
 
@@ -2822,8 +2845,9 @@ void SettingMain(stop_token sT)
 								vec.emplace_back(_strdup((IA(I18nKey.SettingsUI.Version.Update.Arch.Arm64)).c_str()));
 
 								int UpdateArchitecture, UpdateArchitectureEcho;
-								if (setlist.updateArchitecture == "win64") UpdateArchitecture = UpdateArchitectureEcho = 0;
-								else if (setlist.updateArchitecture == "arm64") UpdateArchitecture = UpdateArchitectureEcho = 2;
+								string updateArchitecture = GetUpdateArchitecture();
+								if (updateArchitecture == "win64") UpdateArchitecture = UpdateArchitectureEcho = 0;
+								else if (updateArchitecture == "arm64") UpdateArchitecture = UpdateArchitectureEcho = 2;
 								else UpdateArchitecture = UpdateArchitectureEcho = 1;
 
 								{
@@ -2844,9 +2868,9 @@ void SettingMain(stop_token sT)
 											UpdateArchitecture = i;
 											if (UpdateArchitectureEcho != UpdateArchitecture)
 											{
-												if (UpdateArchitecture == 0) setlist.updateArchitecture = "win64";
-												else if (UpdateArchitecture == 2) setlist.updateArchitecture = "arm64";
-												else setlist.updateArchitecture = "win32";
+												if (UpdateArchitecture == 0) SetUpdateArchitecture("win64");
+												else if (UpdateArchitecture == 2) SetUpdateArchitecture("arm64");
+												else SetUpdateArchitecture("win32");
 
 												WriteSetting();
 
@@ -10330,10 +10354,11 @@ void SettingMain(stop_token sT)
 							PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
 
 							string channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Other) + ")";
-							if (setlist.UpdateChannel == "LTS") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.LTS) + ")";
-							else if (setlist.UpdateChannel == "Insider") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Insider) + ")";
-							else if (setlist.UpdateChannel == "Dev") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Dev) + ")";
-							else if (setlist.UpdateChannel == "Canary") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Canary) + ")";
+							string updateChannel = GetUpdateChannel();
+							if (updateChannel == "LTS") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.LTS) + ")";
+							else if (updateChannel == "Insider") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Insider) + ")";
+							else if (updateChannel == "Dev") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Dev) + ")";
+							else if (updateChannel == "Canary") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Canary) + ")";
 
 							ImGui::TextUnformatted((IA(I18nKey.SettingsUI.Update.Latest) + channel).c_str());
 						}
@@ -10365,10 +10390,11 @@ void SettingMain(stop_token sT)
 							PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 255));
 
 							string channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Other) + ")";
-							if (setlist.UpdateChannel == "LTS") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.LTS) + ")";
-							else if (setlist.UpdateChannel == "Insider") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Insider) + ")";
-							else if (setlist.UpdateChannel == "Dev") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Dev) + ")";
-							else if (setlist.UpdateChannel == "Canary") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Canary) + ")";
+							string updateChannel = GetUpdateChannel();
+							if (updateChannel == "LTS") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.LTS) + ")";
+							else if (updateChannel == "Insider") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Insider) + ")";
+							else if (updateChannel == "Dev") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Dev) + ")";
+							else if (updateChannel == "Canary") channel = " (" + IA(I18nKey.SettingsUI.Update.Channel.Canary) + ")";
 
 							ImGui::TextUnformatted((IA(I18nKey.SettingsUI.Update.Newer) + channel).c_str());
 						}

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -221,6 +221,28 @@ void SettingWindowBegin()
 
 void SettingMain(stop_token sT)
 {
+	auto ClearUpdateRestartInstaller = []()
+		{
+			error_code ec;
+			if (_waccess((globalPath + L"installer").c_str(), 4) != 0) return true;
+
+			filesystem::remove_all(globalPath + L"installer", ec);
+			if (ec)
+			{
+				if (IDTLogger) IDTLogger->error("[SettingMain] 删除更新安装目录失败: {}", ec.message());
+				return false;
+			}
+
+			filesystem::create_directory(globalPath + L"installer", ec);
+			if (ec)
+			{
+				if (IDTLogger) IDTLogger->error("[SettingMain] 重建更新安装目录失败: {}", ec.message());
+				return false;
+			}
+
+			return true;
+		};
+
 	bool showWindow = false;
 	while (!sT.stop_requested())
 	{
@@ -2605,13 +2627,8 @@ void SettingMain(stop_token sT)
 
 									if (!setlist.enableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 									{
-										error_code ec;
-										if (_waccess((globalPath + L"installer").c_str(), 4) == 0)
-										{
-											filesystem::remove_all(globalPath + L"installer", ec);
-											filesystem::create_directory(globalPath + L"installer", ec);
-										}
-										AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+										if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+										else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
 									}
 									else if (setlist.enableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateNew)
 									{
@@ -2740,14 +2757,10 @@ void SettingMain(stop_token sT)
 
 												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 												{
-													error_code ec;
-													if (_waccess((globalPath + L"installer").c_str(), 4) == 0)
-													{
-														filesystem::remove_all(globalPath + L"installer", ec);
-														filesystem::create_directory(globalPath + L"installer", ec);
-													}
+													if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
 												}
-												AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+												else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
 											}
 										}
 										if (is_selected) ImGui::SetItemDefaultFocus();
@@ -2839,14 +2852,10 @@ void SettingMain(stop_token sT)
 
 												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 												{
-													error_code ec;
-													if (_waccess((globalPath + L"installer").c_str(), 4) == 0)
-													{
-														filesystem::remove_all(globalPath + L"installer", ec);
-														filesystem::create_directory(globalPath + L"installer", ec);
-													}
+													if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
 												}
-												if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
+												else if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
 												{
 													AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
 												}

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -2738,6 +2738,15 @@ void SettingMain(stop_token sT)
 
 												WriteSetting();
 
+												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
+												{
+													error_code ec;
+													if (_waccess((globalPath + L"installer").c_str(), 4) == 0)
+													{
+														filesystem::remove_all(globalPath + L"installer", ec);
+														filesystem::create_directory(globalPath + L"installer", ec);
+													}
+												}
 												AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
 											}
 										}
@@ -2828,6 +2837,15 @@ void SettingMain(stop_token sT)
 
 												WriteSetting();
 
+												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
+												{
+													error_code ec;
+													if (_waccess((globalPath + L"installer").c_str(), 4) == 0)
+													{
+														filesystem::remove_all(globalPath + L"installer", ec);
+														filesystem::create_directory(globalPath + L"installer", ec);
+													}
+												}
 												if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
 												{
 													AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;


### PR DESCRIPTION
Add handling for update channels in the updater: include a "channel" field in the update JSON, parse it into tchannel, and require editionInfo.channel to match tchannel when validating downloaded installers. Detect when the update target (channel or architecture) changes during UpdateRestart: remove the existing installer directory, set a flag to re-obtain update information, and restart the obtain-info state. Also ensure that when settings are saved while in UpdateRestart, the installer directory is removed and recreated to avoid stale installer artifacts. These changes prevent applying mismatched installers after switching update channel or architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 强化自动更新校验：更新元数据必须包含频道信息，缺失或不匹配将被视为损坏并触发重新获取。
  * 若更新目标与当前配置不一致，会清理安装器缓存并重启更新流程，避免错误跳过或重启失败。

* **重构**
  * 更新设置访问已改为线程安全，切换频道或架构时会重置安装器并正确更新自动更新状态。
  * UI 状态文本现在通过统一接口显示频道名称，提升一致性。

* **其他**
  * 自动更新后台流程在更多构建中启动，版本元数据已更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->