### PR TITLE
Add config upload info and use in updater

### DIFF
--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -270,6 +270,11 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 		if (targetArchitecture == L"win64" && programArchitecture != L"win64") inconsistentArchitecture = true;
 		if (targetArchitecture == L"win32" && programArchitecture != L"win32") inconsistentArchitecture = true;
 	}
+	// 检查系统版本
+	{
+		IdtSysVersionStruct windowsVersion = GetWindowsVersion();
+		windowsEdition = to_wstring(windowsVersion.majorVersion) + L"." + to_wstring(windowsVersion.minorVersion) + L"." + to_wstring(windowsVersion.buildNumber);
+	}
 	// 程序自动更新
 	{
 		if (_waccess((globalPath + L"update.json").c_str(), 4) == 0)
@@ -1104,12 +1109,6 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 	}
 	// 自动更新初始化
 	{
-		// 检查系统版本
-		{
-			IdtSysVersionStruct windowsVersion = GetWindowsVersion();
-			windowsEdition = to_wstring(windowsVersion.majorVersion) + L"." + to_wstring(windowsVersion.minorVersion) + L"." + to_wstring(windowsVersion.buildNumber);
-		}
-
 	#ifdef IDT_RELEASE
 		thread(AutomaticUpdate).detach();
 	#endif

--- a/Inkeys/Inkeys/Net/Net.Update.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.cpp
@@ -11,6 +11,7 @@ module Inkeys.Net.Update;
 import :Download;
 
 import Inkeys.Conv.Text;
+import Inkeys.Other.Config;
 
 // 程序自动更新
 
@@ -36,13 +37,7 @@ wstring convertToHttp(const wstring& url)
 
 string GetRefererInfo()
 {
-	string ret;
-	ret += utf16ToUtf8(editionDate) + ",";
-	ret += utf16ToUtf8(programArchitecture) + ",";
-	ret += setlist.UpdateChannel + ",";
-	ret += setlist.enableAutoUpdate ? "true," : "false,";
-	ret += utf16ToUtf8(windowsEdition);
-	return ret;
+	return Inkeys::config.GetUploadInfo();
 }
 
 EditionInfoClass GetEditionInfo(string channel, string arch)

--- a/Inkeys/Inkeys/Other/Other.Config.cpp
+++ b/Inkeys/Inkeys/Other/Other.Config.cpp
@@ -3,6 +3,7 @@ module;
 #include "../../IdtMain.h"
 
 #include <initializer_list>
+#include <sstream>
 #include <string_view>
 #include <vector>
 
@@ -300,6 +301,32 @@ namespace
 		return value.load();
 	}
 
+	std::string JsonValueToUploadText(const Json::Value& jsonValue)
+	{
+		if (jsonValue.isString()) return jsonValue.asString();
+		if (jsonValue.isBool()) return jsonValue.asBool() ? "true" : "false";
+		if (jsonValue.isInt64()) return std::to_string(jsonValue.asInt64());
+		if (jsonValue.isUInt64()) return std::to_string(jsonValue.asUInt64());
+		if (jsonValue.isDouble())
+		{
+			std::ostringstream stream;
+			stream << jsonValue.asDouble();
+			return stream.str();
+		}
+
+		Json::StreamWriterBuilder writerBuilder;
+		writerBuilder["indentation"] = "";
+		return Json::writeString(writerBuilder, jsonValue);
+	}
+
+	void MakeUploadTextSingleLine(std::string& text)
+	{
+		for (char& ch : text)
+		{
+			if (ch == '\r' || ch == '\n') ch = ' ';
+		}
+	}
+
 	class DefaultValueHandler
 	{
 	public:
@@ -317,7 +344,7 @@ namespace
 		}
 
 		template <typename T>
-		void HandleValue(const char* name, T& value, const T& defaultValue, bool)
+		void HandleValue(const char* name, T& value, const T& defaultValue, bool, Inkeys::ConfigUploadMode)
 		{
 			if (!IsSelectedValuePath(JoinPath(groupPath, name), selectedPaths)) return;
 			AssignConfigValue(value, defaultValue);
@@ -345,7 +372,7 @@ namespace
 		}
 
 		template <typename T>
-		void HandleValue(const char* name, T& value, const T&, bool canReadFromDocument)
+		void HandleValue(const char* name, T& value, const T&, bool canReadFromDocument, Inkeys::ConfigUploadMode)
 		{
 			if (!canReadFromDocument && !includeWriteOnly) return;
 			if (!IsSelectedValuePath(JoinPath(groupPath, name), selectedPaths)) return;
@@ -383,7 +410,7 @@ namespace
 		}
 
 		template <typename T>
-		void HandleValue(const char* name, T& value, const T&, bool)
+		void HandleValue(const char* name, T& value, const T&, bool, Inkeys::ConfigUploadMode)
 		{
 			Json::Value& parent = EnsureObjectPath(root, groupPath);
 			parent[name] = JsonScalarTraits<T>::ToJson(value);
@@ -391,6 +418,43 @@ namespace
 
 	private:
 		Json::Value& root;
+		std::vector<std::string> groupPath;
+	};
+
+	class UploadInfoHandler
+	{
+	public:
+		void EnterGroup(const char* name)
+		{
+			groupPath.emplace_back(name);
+		}
+
+		void LeaveGroup()
+		{
+			if (!groupPath.empty()) groupPath.pop_back();
+		}
+
+		template <typename T>
+		void HandleValue(const char* name, T& value, const T&, bool, Inkeys::ConfigUploadMode uploadMode)
+		{
+			if (uploadMode != Inkeys::ConfigUploadMode::Upload) return;
+
+			std::string valueText = JsonValueToUploadText(JsonScalarTraits<T>::ToJson(value));
+			MakeUploadTextSingleLine(valueText);
+
+			result += JoinPath(groupPath, name);
+			result += '=';
+			result += valueText;
+			result += ';';
+		}
+
+		const std::string& GetResult() const
+		{
+			return result;
+		}
+
+	private:
+		std::string result;
 		std::vector<std::string> groupPath;
 	};
 }
@@ -462,6 +526,14 @@ namespace Inkeys
 		readAllDocument = outputRoot;
 		hasReadAllDocument = true;
 		return true;
+	}
+
+	std::string Config::GetUploadInfo()
+	{
+		shared_lock<shared_mutex> lock(rwMutex);
+		UploadInfoHandler handler;
+		TraverseSchema(handler);
+		return handler.GetResult();
 	}
 
 	std::wstring Config::GetFilePath() const

--- a/Inkeys/Inkeys/Other/Other.Config.cppm
+++ b/Inkeys/Inkeys/Other/Other.Config.cppm
@@ -9,6 +9,15 @@
 
 export module Inkeys.Other.Config;
 
+export namespace Inkeys
+{
+	enum class ConfigUploadMode
+	{
+		NoUpload,
+		Upload
+	};
+}
+
 namespace Inkeys::ConfigDetail
 {
 	template <typename HandlerT>
@@ -26,9 +35,9 @@ namespace Inkeys::ConfigDetail
 		}
 
 		template <typename ValueT>
-		void Value(const char* name, ValueT& value, const ValueT& defaultValue, bool canReadFromDocument)
+		void Value(const char* name, ValueT& value, const ValueT& defaultValue, bool canReadFromDocument, Inkeys::ConfigUploadMode uploadMode)
 		{
-			handler.HandleValue(name, value, defaultValue, canReadFromDocument);
+			handler.HandleValue(name, value, defaultValue, canReadFromDocument, uploadMode);
 		}
 
 	private:
@@ -38,22 +47,22 @@ namespace Inkeys::ConfigDetail
 
 #define INKEYS_CONFIG_SCHEMA(GROUP, X, H) \
 	GROUP(Config, \
-		X(IdtAtomic<bool>, AutoClean, false) \
+		X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, AutoClean, false) \
 	) \
 	GROUP(Info, \
-		H(std::wstring, userId, ::userId) \
-		H(std::wstring, editionVersion, ::editionVersion) \
-		H(std::wstring, editionDate, ::editionDate) \
-		H(std::wstring, programArchitecture, ::programArchitecture) \
-		H(std::wstring, targetArchitecture, ::targetArchitecture) \
+		H(ConfigUploadMode::Upload, std::wstring, userId, ::userId) \
+		H(ConfigUploadMode::Upload, std::wstring, editionVersion, ::editionVersion) \
+		H(ConfigUploadMode::Upload, std::wstring, editionDate, ::editionDate) \
+		H(ConfigUploadMode::Upload, std::wstring, programArchitecture, ::programArchitecture) \
+		H(ConfigUploadMode::Upload, std::wstring, targetArchitecture, ::targetArchitecture) \
 	) \
 	GROUP(PlugIn, \
 		GROUP(PPTHelper, \
-			X(IdtAtomic<bool>, AutoTakeOver, false) \
-			X(IdtAtomic<bool>, AutoTakeOverOnce, true) \
-			X(IdtAtomic<bool>, AutoTakeOverExpand, true) \
+			X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, AutoTakeOver, false) \
+			X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, AutoTakeOverOnce, true) \
+			X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, AutoTakeOverExpand, true) \
 			GROUP(Tentative, \
-				X(IdtAtomic<bool>, EnablePageButtonLongPress, false) \
+				X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, EnablePageButtonLongPress, false) \
 			) \
 		) \
 	)
@@ -75,7 +84,7 @@ namespace Inkeys
 	{
 	public:
 	#define INKEYS_CONFIG_DECLARE_GROUP(groupName, ...) struct groupName##_Node { __VA_ARGS__ } groupName;
-	#define INKEYS_CONFIG_DECLARE_VALUE(valueType, valueName, defaultValue) valueType valueName{ defaultValue };
+	#define INKEYS_CONFIG_DECLARE_VALUE(uploadMode, valueType, valueName, defaultValue) valueType valueName{ defaultValue };
 		INKEYS_CONFIG_SCHEMA(INKEYS_CONFIG_DECLARE_GROUP, INKEYS_CONFIG_DECLARE_VALUE, INKEYS_CONFIG_DECLARE_VALUE)
 		#undef INKEYS_CONFIG_DECLARE_GROUP
 		#undef INKEYS_CONFIG_DECLARE_VALUE
@@ -86,6 +95,7 @@ namespace Inkeys
 		bool ReadAll();
 		bool ReadMini(std::initializer_list<std::string_view> paths);
 		bool Write();
+		std::string GetUploadInfo();
 		std::wstring GetFilePath() const;
 		void ResetToDefaults();
 
@@ -105,8 +115,8 @@ namespace Inkeys
 			Inkeys::ConfigDetail::SchemaWalker<HandlerT> walker(handler);
 
 		#define INKEYS_CONFIG_TRAVERSE_GROUP(groupName, ...) walker.BeginGroup(#groupName, group.groupName, [&](auto& group) { __VA_ARGS__ });
-		#define INKEYS_CONFIG_TRAVERSE_X_VALUE(valueType, valueName, defaultValue) walker.Value(#valueName, group.valueName, valueType{ defaultValue }, true);
-		#define INKEYS_CONFIG_TRAVERSE_H_VALUE(valueType, valueName, defaultValue) walker.Value(#valueName, group.valueName, valueType{ defaultValue }, false);
+		#define INKEYS_CONFIG_TRAVERSE_X_VALUE(uploadMode, valueType, valueName, defaultValue) walker.Value(#valueName, group.valueName, valueType{ defaultValue }, true, uploadMode);
+		#define INKEYS_CONFIG_TRAVERSE_H_VALUE(uploadMode, valueType, valueName, defaultValue) walker.Value(#valueName, group.valueName, valueType{ defaultValue }, false, uploadMode);
 			INKEYS_CONFIG_SCHEMA(INKEYS_CONFIG_TRAVERSE_GROUP, INKEYS_CONFIG_TRAVERSE_X_VALUE, INKEYS_CONFIG_TRAVERSE_H_VALUE)
 			#undef INKEYS_CONFIG_TRAVERSE_GROUP
 			#undef INKEYS_CONFIG_TRAVERSE_X_VALUE
@@ -154,12 +164,12 @@ namespace Inkeys
 不再手动修改其他结构体、反射表、读写逻辑。
 
 一、添加一个配置项
-直接在目标 GROUP 内新增一行 X(type, name, defaultValue)。
+直接在目标 GROUP 内新增一行 X(ConfigUploadMode::NoUpload, type, name, defaultValue)。
 
 示例：
 GROUP(Config, \
-	X(IdtAtomic<bool>, autoClean, false) \
-	X(int, saveVersion, 1) \
+	X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, autoClean, false) \
+	X(ConfigUploadMode::NoUpload, int, saveVersion, 1) \
 )
 
 添加后即可自动获得：
@@ -172,14 +182,14 @@ GROUP(Config, \
 直接修改对应的 X(...) 即可。
 
 示例：
-X(bool, autoClean, false)
+X(ConfigUploadMode::NoUpload, bool, autoClean, false)
 改成
-X(IdtAtomic<bool>, autoClean, false)
+X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, autoClean, false)
 
 或者：
-X(int, saveVersion, 1)
+X(ConfigUploadMode::NoUpload, int, saveVersion, 1)
 改成
-X(int, saveVersion, 2)
+X(ConfigUploadMode::NoUpload, int, saveVersion, 2)
 
 说明：
 1. 改类型：只改这一处即可。
@@ -194,7 +204,7 @@ X(int, saveVersion, 2)
 
 示例：
 删除
-X(IdtAtomic<bool>, autoTakeOverExpand, false)
+X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, autoTakeOverExpand, false)
 
 说明：
 1. 代码里的成员访问路径会同步消失。
@@ -208,7 +218,7 @@ X(IdtAtomic<bool>, autoTakeOverExpand, false)
 GROUP(Experimental, \
 	GROUP(Inkeys3, \
 		GROUP(UI3, \
-			X(IdtAtomic<bool>, enable, false) \
+			X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, enable, false) \
 		) \
 	) \
 )


### PR DESCRIPTION
Introduce a ConfigUploadMode and upload serialization so configuration values can be exported as a single-line upload string, and use that string in the updater's referer info.

- Inkeys/IdtMain.cpp: remove duplicated Windows version check by moving version collection earlier.
- Inkeys/Inkeys/Net/Net.Update.cpp: import Inkeys.Other.Config and replace manual referer assembly with Inkeys::config.GetUploadInfo().
- Inkeys/Inkeys/Other/Other.Config.cpp(.cppm): add JsonValueToUploadText and MakeUploadTextSingleLine helpers, implement UploadInfoHandler and Config::GetUploadInfo(), add sstream include; update handler interfaces to accept ConfigUploadMode and produce semicolon-separated key=value pairs for uploadable fields.

This change centralizes upload string generation, allows marking which config fields should be uploaded, and cleans up duplicated version-check logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 调整系统初始化顺序，提前获取并记录 Windows 系统版本信息。
  * 修正自动更新启动逻辑，发布版中以不同方式启动/分离更新线程以改善稳定性。

* **新功能**
  * 增加统一的配置上传信息生成功能，封装并返回可用于上报的配置信息文本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->