### PR TITLE
Add windowsEdition config and bump version

### DIFF
--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -53,8 +53,8 @@ import Inkeys.Other.Config;
 #pragma comment(lib, "netapi32.lib")
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
-wstring editionVersion = L"3.0.0-dev.39";		// 程序发布版本
-wstring editionDate = L"20260501a";				// 程序发布日期
+wstring editionVersion = L"3.0.0-dev.47";		// 程序发布版本
+wstring editionDate = L"20260502a";				// 程序发布日期
 
 wstring userId;									// 用户GUID
 wstring globalPath;								// 程序当前路径
@@ -62,6 +62,7 @@ wstring pluginPath;								// 数据保存的路径
 
 wstring programArchitecture = L"win32";
 wstring targetArchitecture = L"win32";
+wstring windowsEdition;
 
 IdtAtomic<int> offSignal;						// 关闭指令
 

--- a/Inkeys/IdtMain.h
+++ b/Inkeys/IdtMain.h
@@ -203,6 +203,7 @@ extern wstring pluginPath;
 
 extern wstring programArchitecture;
 extern wstring targetArchitecture;
+extern wstring windowsEdition;
 
 void CloseProgram();
 void RestartProgram();

--- a/Inkeys/Inkeys/Net/Net.Update.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.cpp
@@ -297,7 +297,6 @@ AutomaticUpdateStateEnum DownloadNewProgram(DownloadNewProgramStateClass* state,
 	return UpdateRestart;
 }
 
-wstring windowsEdition;
 IdtAtomic<int> downloadLine = 1;
 
 void AutomaticUpdate()

--- a/Inkeys/Inkeys/Net/Net.Update.cppm
+++ b/Inkeys/Inkeys/Net/Net.Update.cppm
@@ -104,7 +104,6 @@ export extern bool inconsistentArchitecture;
 wstring get_domain_name(wstring url);
 wstring convertToHttp(const wstring& url);
 
-export extern wstring windowsEdition;
 export extern IdtAtomic<int> downloadLine;
 
 export void AutomaticUpdate();

--- a/Inkeys/Inkeys/Other/Other.Config.cppm
+++ b/Inkeys/Inkeys/Other/Other.Config.cppm
@@ -50,11 +50,12 @@ namespace Inkeys::ConfigDetail
 		X(ConfigUploadMode::NoUpload, IdtAtomic<bool>, AutoClean, false) \
 	) \
 	GROUP(Info, \
-		H(ConfigUploadMode::Upload, std::wstring, userId, ::userId) \
-		H(ConfigUploadMode::Upload, std::wstring, editionVersion, ::editionVersion) \
-		H(ConfigUploadMode::Upload, std::wstring, editionDate, ::editionDate) \
-		H(ConfigUploadMode::Upload, std::wstring, programArchitecture, ::programArchitecture) \
-		H(ConfigUploadMode::Upload, std::wstring, targetArchitecture, ::targetArchitecture) \
+		H(ConfigUploadMode::Upload, std::wstring, UserId, ::userId) \
+		H(ConfigUploadMode::Upload, std::wstring, EditionVersion, ::editionVersion) \
+		H(ConfigUploadMode::Upload, std::wstring, EditionDate, ::editionDate) \
+		H(ConfigUploadMode::Upload, std::wstring, ProgramArchitecture, ::programArchitecture) \
+		H(ConfigUploadMode::Upload, std::wstring, TargetArchitecture, ::targetArchitecture) \
+		H(ConfigUploadMode::Upload, std::wstring, WindowsEdition, ::windowsEdition) \
 	) \
 	GROUP(PlugIn, \
 		GROUP(PPTHelper, \


### PR DESCRIPTION
Bump release metadata and add Windows edition support. Updated editionVersion to 3.0.0-dev.47 and editionDate to 20260502a in IdtMain.cpp. Introduced a global wstring windowsEdition (declared in IdtMain.h and defined in IdtMain.cpp), removed a duplicate local declaration in Net.Update.cpp and removed its export from Net.Update.cppm. Updated ConfigDetail mapping in Other.Config.cppm: renamed several Info keys to PascalCase (UserId, EditionVersion, EditionDate, ProgramArchitecture, TargetArchitecture) and added WindowsEdition so the Windows edition is included in config uploads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **版本更新**
  * 应用版本更新至 3.0.0-dev.47
  * 发布日期更新至 20260502a

* **功能优化**
  * 新增 Windows 版本识别信息
  * 配置架构调整，增强系统信息收集能力

<!-- end of auto-generated comment: release notes by coderabbit.ai -->