### PR TITLE
Thread-safe update config and async SecRandom

### DIFF
--- a/Inkeys/IdtConfiguration.cpp
+++ b/Inkeys/IdtConfiguration.cpp
@@ -204,10 +204,10 @@ bool ReadSetting()
 
 		if (setlistVal.isMember("UpdateSetting") && setlistVal["UpdateSetting"].isObject())
 		{
-			if (setlistVal["UpdateSetting"].isMember("EnableAutoUpdate") && setlistVal["UpdateSetting"]["EnableAutoUpdate"].isBool())
-				setlist.enableAutoUpdate = setlistVal["UpdateSetting"]["EnableAutoUpdate"].asBool();
 			{
 				unique_lock<shared_mutex> lock(setlistUpdateMutex);
+				if (setlistVal["UpdateSetting"].isMember("EnableAutoUpdate") && setlistVal["UpdateSetting"]["EnableAutoUpdate"].isBool())
+					setlist.enableAutoUpdate = setlistVal["UpdateSetting"]["EnableAutoUpdate"].asBool();
 				if (setlistVal["UpdateSetting"].isMember("UpdateChannel") && setlistVal["UpdateSetting"]["UpdateChannel"].isString())
 					setlist.UpdateChannel = setlistVal["UpdateSetting"]["UpdateChannel"].asString();
 				if (setlistVal["UpdateSetting"].isMember("UpdateArchitecture") && setlistVal["UpdateSetting"]["UpdateArchitecture"].isString())
@@ -415,10 +415,12 @@ bool WriteSetting()
 {
 	if (Inkeys::config.Config.AutoClean) setlistVal.clear();
 
+	bool enableAutoUpdate;
 	string updateChannel;
 	string updateArchitecture;
 	{
 		shared_lock<shared_mutex> lock(setlistUpdateMutex);
+		enableAutoUpdate = setlist.enableAutoUpdate;
 		updateChannel = setlist.UpdateChannel;
 		updateArchitecture = setlist.updateArchitecture;
 	}
@@ -472,7 +474,7 @@ bool WriteSetting()
 		}
 
 		{
-			setlistVal["UpdateSetting"]["EnableAutoUpdate"] = Json::Value(setlist.enableAutoUpdate);
+			setlistVal["UpdateSetting"]["EnableAutoUpdate"] = Json::Value(enableAutoUpdate);
 			setlistVal["UpdateSetting"]["UpdateChannel"] = Json::Value(updateChannel);
 			setlistVal["UpdateSetting"]["UpdateArchitecture"] = Json::Value(updateArchitecture);
 		}

--- a/Inkeys/IdtMain.cpp
+++ b/Inkeys/IdtMain.cpp
@@ -53,8 +53,8 @@ import Inkeys.Other.Config;
 #pragma comment(lib, "netapi32.lib")
 
 wstring buildTime = __DATE__ L" " __TIME__;		// 构建时间
-wstring editionVersion = L"3.0.0-dev.74";		// 程序发布版本
-wstring editionDate = L"20260502b";				// 程序发布日期
+wstring editionVersion = L"3.0.0-dev.76";		// 程序发布版本
+wstring editionDate = L"20260503a";				// 程序发布日期
 
 wstring userId;									// 用户GUID
 wstring globalPath;								// 程序当前路径
@@ -840,6 +840,7 @@ int WINAPI wWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPWSTR
 		{
 			// 软件版本
 			{
+				unique_lock<shared_mutex> lock(setlistUpdateMutex);
 				setlist.enableAutoUpdate = true;
 				setlist.UpdateChannel = "LTS";
 				{

--- a/Inkeys/Inkeys.vcxproj.filters
+++ b/Inkeys/Inkeys.vcxproj.filters
@@ -85,18 +85,6 @@
     <Filter Include="Modules\Inkeys\Helper">
       <UniqueIdentifier>{27615d57-79cc-4874-bfe3-3d8915419a1e}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Modules\Inkeys3Temp">
-      <UniqueIdentifier>{044aa458-472c-460b-87d1-33cd548fccb9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Modules\Inkeys3Temp\Rendering">
-      <UniqueIdentifier>{2eb257ad-d9da-48c0-97cf-3942f6fce468}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Modules\Inkeys3Temp\UI">
-      <UniqueIdentifier>{f9757343-bc73-4e18-9870-96f2116624ab}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Modules\Inkeys3Temp\UI\Setting">
-      <UniqueIdentifier>{e0a90257-b851-4dca-9396-daa6bded23cb}</UniqueIdentifier>
-    </Filter>
     <Filter Include="头文件\Additional\Imgui\CustomShaders">
       <UniqueIdentifier>{db9757aa-b695-415a-8971-7e820af31043}</UniqueIdentifier>
     </Filter>

--- a/Inkeys/Inkeys/Helper/Helper.SecRandom.cppm
+++ b/Inkeys/Inkeys/Helper/Helper.SecRandom.cppm
@@ -136,17 +136,62 @@ namespace
 		return text;
 	}
 
-	bool ConnectPipe(std::wstring_view ipcName, DWORD timeoutMs, UniqueHandle& pipeHandle, std::wstring* errorMessage)
+	DWORD GetRemainingTimeoutMs(const std::chrono::steady_clock::time_point& deadline)
+	{
+		const auto now = std::chrono::steady_clock::now();
+		if (now >= deadline) return 0;
+
+		const auto remainingMs = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+		if (remainingMs <= 0) return 1;
+		if (remainingMs > static_cast<long long>(numeric_limits<DWORD>::max())) return numeric_limits<DWORD>::max();
+		return static_cast<DWORD>(remainingMs);
+	}
+
+	bool WaitForPipeOperation(HANDLE pipeHandle, OVERLAPPED& overlapped, DWORD& transferred, const std::chrono::steady_clock::time_point& deadline, const std::wstring& timeoutMessage, const std::wstring& failurePrefix, std::wstring* errorMessage)
+	{
+		const DWORD waitMs = GetRemainingTimeoutMs(deadline);
+		const DWORD waitResult = WaitForSingleObject(overlapped.hEvent, waitMs);
+		if (waitResult == WAIT_OBJECT_0)
+		{
+			if (GetOverlappedResult(pipeHandle, &overlapped, &transferred, FALSE)) return true;
+
+			const DWORD lastError = GetLastError();
+			AssignError(errorMessage, failurePrefix + FormatWindowsErrorDetail(lastError));
+			return false;
+		}
+		if (waitResult == WAIT_TIMEOUT)
+		{
+			CancelIo(pipeHandle);
+			DWORD ignored = 0;
+			GetOverlappedResult(pipeHandle, &overlapped, &ignored, TRUE);
+			AssignError(errorMessage, timeoutMessage);
+			return false;
+		}
+
+		const DWORD lastError = GetLastError();
+		AssignError(errorMessage, failurePrefix + FormatWindowsErrorDetail(lastError));
+		return false;
+	}
+
+	bool ConnectPipe(std::wstring_view ipcName, const std::chrono::steady_clock::time_point& deadline, UniqueHandle& pipeHandle, std::wstring* errorMessage)
 	{
 		const std::wstring pipePath = BuildPipePath(ipcName);
-		const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
-		const DWORD pipeClientFlags = SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION;
+		const DWORD pipeClientFlags = FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION;
 
 		while (true)
 		{
 			HANDLE rawHandle = CreateFileW(pipePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, pipeClientFlags, nullptr);
 			if (rawHandle != INVALID_HANDLE_VALUE)
 			{
+				DWORD pipeMode = PIPE_READMODE_BYTE;
+				if (!SetNamedPipeHandleState(rawHandle, &pipeMode, nullptr, nullptr))
+				{
+					DWORD modeError = GetLastError();
+					CloseHandle(rawHandle);
+					AssignError(errorMessage, L"设置 SecRandom IPC 管道读取模式失败: " + FormatWindowsErrorDetail(modeError));
+					return false;
+				}
+
 				pipeHandle.Reset(rawHandle);
 				return true;
 			}
@@ -177,9 +222,8 @@ namespace
 				return false;
 			}
 
-			const auto now = std::chrono::steady_clock::now();
-			const auto remainingMs = deadline > now ? std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count() : 0;
-			DWORD waitSlice = static_cast<DWORD>(remainingMs > 1000 ? 1000 : remainingMs);
+			const DWORD remainingMs = GetRemainingTimeoutMs(deadline);
+			DWORD waitSlice = remainingMs > 1000 ? 1000 : remainingMs;
 			if (waitSlice == 0) waitSlice = 1;
 
 			if (lastError == ERROR_FILE_NOT_FOUND)
@@ -200,16 +244,45 @@ namespace
 		}
 	}
 
-	bool WriteAll(HANDLE pipeHandle, const char* buffer, size_t length, std::wstring* errorMessage)
+	bool WriteAll(HANDLE pipeHandle, const char* buffer, size_t length, const std::chrono::steady_clock::time_point& deadline, std::wstring* errorMessage)
 	{
 		size_t offset = 0;
 		while (offset < length)
 		{
+			if (GetRemainingTimeoutMs(deadline) == 0)
+			{
+				AssignError(errorMessage, L"写入 SecRandom IPC 管道超时。");
+				return false;
+			}
+
+			UniqueHandle eventHandle(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+			if (!eventHandle)
+			{
+				AssignError(errorMessage, L"创建 SecRandom IPC 写入事件失败: " + FormatWindowsErrorDetail(GetLastError()));
+				return false;
+			}
+
+			OVERLAPPED overlapped = {};
+			overlapped.hEvent = eventHandle.Get();
+
 			DWORD written = 0;
 			DWORD chunkLength = static_cast<DWORD>(min<size_t>(length - offset, numeric_limits<DWORD>::max()));
-			if (!WriteFile(pipeHandle, buffer + offset, chunkLength, &written, nullptr))
+			if (!WriteFile(pipeHandle, buffer + offset, chunkLength, nullptr, &overlapped))
 			{
-				AssignError(errorMessage, L"写入 SecRandom IPC 管道失败: " + FormatWindowsErrorMessage(GetLastError()));
+				const DWORD lastError = GetLastError();
+				if (lastError == ERROR_IO_PENDING)
+				{
+					if (!WaitForPipeOperation(pipeHandle, overlapped, written, deadline, L"写入 SecRandom IPC 管道超时。", L"写入 SecRandom IPC 管道失败: ", errorMessage)) return false;
+				}
+				else
+				{
+					AssignError(errorMessage, L"写入 SecRandom IPC 管道失败: " + FormatWindowsErrorDetail(lastError));
+					return false;
+				}
+			}
+			else if (!GetOverlappedResult(pipeHandle, &overlapped, &written, FALSE))
+			{
+				AssignError(errorMessage, L"写入 SecRandom IPC 管道失败: " + FormatWindowsErrorDetail(GetLastError()));
 				return false;
 			}
 			if (written == 0)
@@ -222,16 +295,47 @@ namespace
 		return true;
 	}
 
-	bool ReadResponseLine(HANDLE pipeHandle, std::string& responseLine, std::wstring* errorMessage)
+	bool ReadResponseLine(HANDLE pipeHandle, std::string& responseLine, const std::chrono::steady_clock::time_point& deadline, std::wstring* errorMessage)
 	{
 		responseLine.clear();
 		vector<char> chunk(512);
 
 		while (true)
 		{
+			if (GetRemainingTimeoutMs(deadline) == 0)
+			{
+				AssignError(errorMessage, L"读取 SecRandom IPC 响应超时。");
+				return false;
+			}
+
+			UniqueHandle eventHandle(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+			if (!eventHandle)
+			{
+				AssignError(errorMessage, L"创建 SecRandom IPC 读取事件失败: " + FormatWindowsErrorDetail(GetLastError()));
+				return false;
+			}
+
+			OVERLAPPED overlapped = {};
+			overlapped.hEvent = eventHandle.Get();
+
 			DWORD readBytes = 0;
-			BOOL readOk = ReadFile(pipeHandle, chunk.data(), static_cast<DWORD>(chunk.size()), &readBytes, nullptr);
+			BOOL readOk = ReadFile(pipeHandle, chunk.data(), static_cast<DWORD>(chunk.size()), nullptr, &overlapped);
 			DWORD lastError = readOk ? ERROR_SUCCESS : GetLastError();
+
+			if (!readOk && lastError == ERROR_IO_PENDING)
+			{
+				if (!WaitForPipeOperation(pipeHandle, overlapped, readBytes, deadline, L"读取 SecRandom IPC 响应超时。", L"读取 SecRandom IPC 响应失败: ", errorMessage)) return false;
+				lastError = ERROR_SUCCESS;
+				readOk = TRUE;
+			}
+			else if (readOk)
+			{
+				if (!GetOverlappedResult(pipeHandle, &overlapped, &readBytes, FALSE))
+				{
+					lastError = GetLastError();
+					readOk = FALSE;
+				}
+			}
 
 			if (readBytes != 0)
 			{
@@ -254,7 +358,7 @@ namespace
 				break;
 			}
 
-			AssignError(errorMessage, L"读取 SecRandom IPC 响应失败: " + FormatWindowsErrorMessage(lastError));
+			AssignError(errorMessage, L"读取 SecRandom IPC 响应失败: " + FormatWindowsErrorDetail(lastError));
 			return false;
 		}
 
@@ -282,7 +386,8 @@ export namespace Inkeys::SecRandom
 	bool SendUrl(std::wstring_view url, std::wstring* errorMessage = nullptr, DWORD timeoutMs = 5000)
 	{
 		UniqueHandle pipeHandle;
-		if (!ConnectPipe(kDefaultIpcName, timeoutMs, pipeHandle, errorMessage)) return false;
+		const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+		if (!ConnectPipe(kDefaultIpcName, deadline, pipeHandle, errorMessage)) return false;
 
 		Json::Value request(Json::objectValue);
 		request["type"] = Json::Value("url");
@@ -293,10 +398,10 @@ export namespace Inkeys::SecRandom
 		std::string requestJson = Json::writeString(writer, request);
 		requestJson.push_back('\n');
 
-		if (!WriteAll(pipeHandle.Get(), requestJson.data(), requestJson.size(), errorMessage)) return false;
+		if (!WriteAll(pipeHandle.Get(), requestJson.data(), requestJson.size(), deadline, errorMessage)) return false;
 
 		std::string responseJson;
-		if (!ReadResponseLine(pipeHandle.Get(), responseJson, errorMessage)) return false;
+		if (!ReadResponseLine(pipeHandle.Get(), responseJson, deadline, errorMessage)) return false;
 
 		Json::CharReaderBuilder reader;
 		reader["collectComments"] = false;

--- a/Inkeys/Inkeys/Net/Net.Update.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.cpp
@@ -24,12 +24,13 @@ namespace
 	{
 		string channel;
 		string architecture;
+		bool enableAutoUpdate;
 	};
 
 	UpdateTargetSnapshot GetUpdateTargetSnapshot()
 	{
 		shared_lock<shared_mutex> lock(setlistUpdateMutex);
-		return { setlist.UpdateChannel, setlist.updateArchitecture };
+		return { setlist.UpdateChannel, setlist.updateArchitecture, setlist.enableAutoUpdate };
 	}
 
 	void SetUpdateChannelSnapshot(const string& channel)
@@ -272,7 +273,7 @@ AutomaticUpdateStateEnum DownloadNewProgram(DownloadNewProgramStateClass* state,
 		//创建 update.json 文件，指示更新
 		if (editionInfo.hash_md5 == hash_md5 && editionInfo.hash_sha256 == hash_sha256)
 		{
-			if (!setlist.enableAutoUpdate && !mandatoryUpdate)
+			if (!GetUpdateTargetSnapshot().enableAutoUpdate && !mandatoryUpdate)
 			{
 				error_code ec;
 				filesystem::remove(globalPath + L"installer\\new_procedure_" + timestamp + L".exe", ec);
@@ -365,7 +366,7 @@ updateStart:
 		}
 
 		//下载最新版本
-		if (state && editionInfo.editionDate != L"" && ((editionInfo.editionDate > editionDate && setlist.enableAutoUpdate) || mandatoryUpdate))
+		if (state && editionInfo.editionDate != L"" && ((editionInfo.editionDate > editionDate && GetUpdateTargetSnapshot().enableAutoUpdate) || mandatoryUpdate))
 		{
 			update = true;
 			if (_waccess((globalPath + L"installer\\update.json").c_str(), 4) == 0 && !mandatoryUpdate)
@@ -422,7 +423,7 @@ updateStart:
 
 					if (tedition == editionInfo.editionDate && _waccess((globalPath + tpath).c_str(), 0) == 0 && hash_md5 == thash_md5 && hash_sha256 == thash_sha256 && editionInfo.channel == tchannel && updateArch == tarch)
 					{
-						if (!setlist.enableAutoUpdate)
+						if (!GetUpdateTargetSnapshot().enableAutoUpdate)
 						{
 							if (_waccess((globalPath + L"installer").c_str(), 0) == 0)
 							{

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -241,26 +241,58 @@ void SettingMain(stop_token sT)
 			unique_lock<shared_mutex> lock(setlistUpdateMutex);
 			setlist.updateArchitecture = architecture;
 		};
-	auto ClearUpdateRestartInstaller = []()
+	auto GetEnableAutoUpdate = []()
 		{
+			shared_lock<shared_mutex> lock(setlistUpdateMutex);
+			return setlist.enableAutoUpdate;
+		};
+	auto SetEnableAutoUpdate = [](bool enable)
+		{
+			unique_lock<shared_mutex> lock(setlistUpdateMutex);
+			setlist.enableAutoUpdate = enable;
+		};
+	enum class ClearInstallerResult
+	{
+		Missing,
+		Cleared,
+		Failed
+	};
+	auto ClearUpdateRestartInstaller = []() -> ClearInstallerResult
+		{
+			const auto installerDir = globalPath + L"installer";
 			error_code ec;
-			if (_waccess((globalPath + L"installer").c_str(), 4) != 0) return true;
+			const bool exists = filesystem::exists(installerDir, ec);
+			if (ec)
+			{
+				if (IDTLogger) IDTLogger->error("[SettingMain] 检查更新安装目录失败: {}", ec.message());
+				return ClearInstallerResult::Failed;
+			}
+			if (!exists)
+			{
+				filesystem::create_directory(installerDir, ec);
+				if (ec)
+				{
+					if (IDTLogger) IDTLogger->error("[SettingMain] 创建更新安装目录失败: {}", ec.message());
+					return ClearInstallerResult::Failed;
+				}
+				return ClearInstallerResult::Missing;
+			}
 
-			filesystem::remove_all(globalPath + L"installer", ec);
+			filesystem::remove_all(installerDir, ec);
 			if (ec)
 			{
 				if (IDTLogger) IDTLogger->error("[SettingMain] 删除更新安装目录失败: {}", ec.message());
-				return false;
+				return ClearInstallerResult::Failed;
 			}
 
-			filesystem::create_directory(globalPath + L"installer", ec);
+			filesystem::create_directory(installerDir, ec);
 			if (ec)
 			{
 				if (IDTLogger) IDTLogger->error("[SettingMain] 重建更新安装目录失败: {}", ec.message());
-				return false;
+				return ClearInstallerResult::Failed;
 			}
 
-			return true;
+			return ClearInstallerResult::Cleared;
 		};
 
 	bool showWindow = false;
@@ -813,7 +845,7 @@ void SettingMain(stop_token sT)
 		}ConfigurationSetting;
 
 		bool EnableFixWithChangeArchitecture = true;
-		bool EnableAutoUpdate = setlist.enableAutoUpdate;
+		bool EnableAutoUpdate = false;
 
 		int SelectLanguage = setlist.selectLanguage;
 		bool StartUp = setlist.startUp;
@@ -986,6 +1018,7 @@ void SettingMain(stop_token sT)
 			ImGui_ImplDX9_NewFrame();
 			ImGui_ImplWin32_NewFrame();
 			ImGui::NewFrame();
+			EnableAutoUpdate = GetEnableAutoUpdate();
 
 			{
 				//定义栏操作
@@ -2629,6 +2662,7 @@ void SettingMain(stop_token sT)
 								PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(0, 0, 0, 15));
 								PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 95, 184, 255));
 								PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(0, 95, 184, 230));
+								const bool enableAutoUpdateSnapshot = EnableAutoUpdate;
 								if (!EnableAutoUpdate)
 								{
 									PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 155));
@@ -2639,21 +2673,28 @@ void SettingMain(stop_token sT)
 									PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 255));
 									PushStyleColorNum++, ImGui::PushStyleColor(ImGuiCol_BorderShadow, IM_COL32(0, 95, 184, 255));
 								}
-								ImGui::Toggle("##自动更新（静默）", &EnableAutoUpdate, config);
+								const bool enableAutoUpdateChanged = ImGui::Toggle("##自动更新（静默）", &EnableAutoUpdate, config);
 
-								if (setlist.enableAutoUpdate != EnableAutoUpdate)
+								if (enableAutoUpdateChanged && enableAutoUpdateSnapshot != EnableAutoUpdate)
 								{
-									setlist.enableAutoUpdate = EnableAutoUpdate;
-									WriteSetting();
-
-									if (!setlist.enableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
+									if (!EnableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 									{
-										if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
-										else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
+										if (ClearUpdateRestartInstaller() != ClearInstallerResult::Failed)
+										{
+											SetEnableAutoUpdate(EnableAutoUpdate);
+											WriteSetting();
+											AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+										}
+										else EnableAutoUpdate = enableAutoUpdateSnapshot;
 									}
-									else if (setlist.enableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateNew)
+									else
 									{
-										AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+										SetEnableAutoUpdate(EnableAutoUpdate);
+										WriteSetting();
+										if (EnableAutoUpdate && AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateNew)
+										{
+											AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+										}
 									}
 								}
 							}
@@ -2775,16 +2816,22 @@ void SettingMain(stop_token sT)
 												if (UpdateChannelMode == 1) selectedUpdateChannel = "Insider";
 												else if (UpdateChannelMode == 2) selectedUpdateChannel = "Canary";
 												else selectedUpdateChannel = "LTS";
-												SetUpdateChannel(selectedUpdateChannel);
-
-												WriteSetting();
 
 												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 												{
-													if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
-													else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
+													if (ClearUpdateRestartInstaller() != ClearInstallerResult::Failed)
+													{
+														SetUpdateChannel(selectedUpdateChannel);
+														WriteSetting();
+														AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													}
 												}
-												else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+												else
+												{
+													SetUpdateChannel(selectedUpdateChannel);
+													WriteSetting();
+													AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+												}
 											}
 										}
 										if (is_selected) ImGui::SetItemDefaultFocus();
@@ -2869,20 +2916,28 @@ void SettingMain(stop_token sT)
 											UpdateArchitecture = i;
 											if (UpdateArchitectureEcho != UpdateArchitecture)
 											{
-												if (UpdateArchitecture == 0) SetUpdateArchitecture("win64");
-												else if (UpdateArchitecture == 2) SetUpdateArchitecture("arm64");
-												else SetUpdateArchitecture("win32");
-
-												WriteSetting();
+												string selectedUpdateArchitecture;
+												if (UpdateArchitecture == 0) selectedUpdateArchitecture = "win64";
+												else if (UpdateArchitecture == 2) selectedUpdateArchitecture = "arm64";
+												else selectedUpdateArchitecture = "win32";
 
 												if (AutomaticUpdateState == AutomaticUpdateStateEnum::UpdateRestart)
 												{
-													if (ClearUpdateRestartInstaller()) AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
-													else AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateNotStarted;
+													if (ClearUpdateRestartInstaller() != ClearInstallerResult::Failed)
+													{
+														SetUpdateArchitecture(selectedUpdateArchitecture);
+														WriteSetting();
+														AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													}
 												}
-												else if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
+												else
 												{
-													AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													SetUpdateArchitecture(selectedUpdateArchitecture);
+													WriteSetting();
+													if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
+													{
+														AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													}
 												}
 											}
 										}

--- a/Inkeys/Inkeys/UI/Setting/Setting.cpp
+++ b/Inkeys/Inkeys/UI/Setting/Setting.cpp
@@ -2830,7 +2830,10 @@ void SettingMain(stop_token sT)
 												{
 													SetUpdateChannel(selectedUpdateChannel);
 													WriteSetting();
-													AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													if (AutomaticUpdateState != AutomaticUpdateStateEnum::UpdateNotStarted)
+													{
+														AutomaticUpdateState = AutomaticUpdateStateEnum::UpdateObtainInformation;
+													}
 												}
 											}
 										}


### PR DESCRIPTION
Make update-related settings thread-safe and introduce robust async IPC for SecRandom.

- Protect setlist.enableAutoUpdate with setlistUpdateMutex when reading/writing settings and at startup; expose snapshot/getter/setter to read/update atomically and use snapshot in Net.Update logic.
- Update UI to read enableAutoUpdate from a snapshot, provide Set/Get helpers, and handle clearing/recreating installer directory with explicit result enum and error logging; ensure settings are written only on successful state transitions.
- Rewrite SecRandom IPC to use overlapped (asynchronous) I/O with event-based waiting and deadline-aware timeouts (GetRemainingTimeoutMs, WaitForPipeOperation), set pipe read mode, and improve error reporting.
- Bump editionVersion/editionDate and initialize default update channel on startup.

These changes fix race conditions around automatic updates, improve IPC reliability and timeout handling, and add safer installer directory operations and clearer error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进自动更新相关的线程安全与状态同步，减少竞态条件和不一致。
  * 重构管道/超时处理为基于截止时间的机制，提升读写与连接的可靠性与超时行为一致性。
  * 优化设置界面在启用/禁用自动更新及更改通道/架构时的状态流转和恢复逻辑；增强安装器清理的鲁棒性。

* **Chores**
  * 更新版本号至 3.0.0-dev.76。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->