### PR TITLE
Add User-Agent header and pass headers to GET

### DIFF
--- a/Inkeys/Inkeys/Net/Net.Update.Download.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.Download.cpp
@@ -88,6 +88,7 @@ bool DownloadEdition(std::string domain, std::string path, std::wstring director
 	{
 		{ "Cache-Control", "no-cache" },
 		{ "Pragma", "no-cache" },
+		{ "User-Agent", "Inkeys-Updater/3.0" },
 		{ "Referer", referer.c_str() }
 	};
 
@@ -109,7 +110,7 @@ bool DownloadEdition(std::string domain, std::string path, std::wstring director
 			httplib::SSLClient scli(domain);
 			scli.set_follow_location(true);
 			scli.set_connection_timeout(5);
-			res = scli.Get(path.c_str(), callback);
+			res = scli.Get(path.c_str(), headers, callback);
 		}
 		file.close();
 	}
@@ -124,7 +125,7 @@ bool DownloadEdition(std::string domain, std::string path, std::wstring director
 			httplib::Client cli(domain);
 			cli.set_follow_location(true);
 			cli.set_connection_timeout(5);
-			res = cli.Get(path.c_str(), callback);
+			res = cli.Get(path.c_str(), headers, callback);
 		}
 		file.close();
 	}


### PR DESCRIPTION
Include a User-Agent header (Inkeys-Updater/3.0) in the request headers and update both SSLClient and Client GET calls to pass the headers map. This ensures the updater identifies itself to servers and that custom headers (e.g., Cache-Control/Pragma/Referer/User-Agent) are actually sent with the request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了更新下载的服务器兼容性，现在在发送下载请求时添加了明确的标识信息头，确保更新过程更加稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->