### PR TITLE
Unify widget dirty rect padding and frame outset

### DIFF
--- a/Inkeys/Inkeys/UI/Bar/Bar.RenderingAttribute.cppm
+++ b/Inkeys/Inkeys/UI/Bar/Bar.RenderingAttribute.cppm
@@ -10,6 +10,8 @@ import :State;
 class BarRenderingAttribute
 {
 public:
+	static constexpr int dirtyAntialiasPadding = 3;
+
 	static void UnionRectInPlace(RECT& target, const RECT& add)
 	{
 		// 新增矩形无效，直接返回
@@ -27,48 +29,54 @@ public:
 		target.bottom = max(target.bottom, add.bottom);
 	}
 
+	static int GetFrameDirtyOutset(const optional<BarUiValueClass>& ft, double tarZoom)
+	{
+		if (!ft.has_value()) return 0;
+
+		// 边框外扩需要折算到设备像素，固定抗锯齿余量在矩形计算处统一追加。
+		return static_cast<int>(ceil(ft.value().val * tarZoom));
+	}
+
 	static RECT GetWeigetRect(const BarUiShapeClass& shape, double tarZoom)
 	{
-		int ft = 0;
-		if (shape.ft.has_value()) ft = static_cast<int>(ceil(shape.ft.value().val));
+		int ft = GetFrameDirtyOutset(shape.ft, tarZoom) + dirtyAntialiasPadding;
 
 		RECT ret;
 		ret.left = static_cast<LONG>(floor(shape.inhX * tarZoom) - ft);
 		ret.top = static_cast<LONG>(floor(shape.inhY * tarZoom) - ft);
-		ret.right = static_cast<LONG>(ceil((shape.inhX + shape.w.val) * tarZoom) + ft) + 1;
-		ret.bottom = static_cast<LONG>(ceil((shape.inhY + shape.h.val) * tarZoom) + ft) + 1;
+		ret.right = static_cast<LONG>(ceil((shape.inhX + shape.w.val) * tarZoom) + ft);
+		ret.bottom = static_cast<LONG>(ceil((shape.inhY + shape.h.val) * tarZoom) + ft);
 
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiSuperellipseClass& superellipse, double tarZoom)
 	{
-		int ft = 0;
-		if (superellipse.ft.has_value()) ft = static_cast<int>(ceil(superellipse.ft.value().val));
+		int ft = GetFrameDirtyOutset(superellipse.ft, tarZoom) + dirtyAntialiasPadding;
 
 		RECT ret;
 		ret.left = static_cast<LONG>(floor(superellipse.inhX * tarZoom) - ft);
 		ret.top = static_cast<LONG>(floor(superellipse.inhY * tarZoom) - ft);
-		ret.right = static_cast<LONG>(ceil((superellipse.inhX + superellipse.w.val) * tarZoom) + ft) + 1;
-		ret.bottom = static_cast<LONG>(ceil((superellipse.inhY + superellipse.h.val) * tarZoom) + ft) + 1;
+		ret.right = static_cast<LONG>(ceil((superellipse.inhX + superellipse.w.val) * tarZoom) + ft);
+		ret.bottom = static_cast<LONG>(ceil((superellipse.inhY + superellipse.h.val) * tarZoom) + ft);
 
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiSVGClass& svg, double tarZoom)
 	{
 		RECT ret;
-		ret.left = static_cast<LONG>(floor(svg.inhX * tarZoom));
-		ret.top = static_cast<LONG>(floor(svg.inhY * tarZoom));
-		ret.right = static_cast<LONG>(ceil((svg.inhX + svg.w.val) * tarZoom)) + 1;
-		ret.bottom = static_cast<LONG>(ceil((svg.inhY + svg.h.val) * tarZoom)) + 1;
+		ret.left = static_cast<LONG>(floor(svg.inhX * tarZoom) - dirtyAntialiasPadding);
+		ret.top = static_cast<LONG>(floor(svg.inhY * tarZoom) - dirtyAntialiasPadding);
+		ret.right = static_cast<LONG>(ceil((svg.inhX + svg.w.val) * tarZoom) + dirtyAntialiasPadding);
+		ret.bottom = static_cast<LONG>(ceil((svg.inhY + svg.h.val) * tarZoom) + dirtyAntialiasPadding);
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiWordClass& word, double tarZoom)
 	{
 		RECT ret;
-		ret.left = static_cast<LONG>(floor(word.inhX * tarZoom));
-		ret.top = static_cast<LONG>(floor(word.inhY * tarZoom));
-		ret.right = static_cast<LONG>(ceil((word.inhX + word.w.val) * tarZoom)) + 1;
-		ret.bottom = static_cast<LONG>(ceil((word.inhY + word.h.val) * tarZoom)) + 1;
+		ret.left = static_cast<LONG>(floor(word.inhX * tarZoom) - dirtyAntialiasPadding);
+		ret.top = static_cast<LONG>(floor(word.inhY * tarZoom) - dirtyAntialiasPadding);
+		ret.right = static_cast<LONG>(ceil((word.inhX + word.w.val) * tarZoom) + dirtyAntialiasPadding);
+		ret.bottom = static_cast<LONG>(ceil((word.inhY + word.h.val) * tarZoom) + dirtyAntialiasPadding);
 		return ret;
 	}
 };


### PR DESCRIPTION
Introduce dirtyAntialiasPadding (3) and GetFrameDirtyOutset(ft, tarZoom) to compute frame expansion in device pixels (ceil(ft * tarZoom)). Use these helpers when computing widget dirty RECTs for shapes and superellipses, and apply antialias padding to SVG and Word rects. Remove previous +1 pixel right/bottom adjustments to avoid double-counting. This centralizes dirty/outset calculation and fixes inconsistent padding when scaling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一了界面元素边缘的外扩与抗锯齿处理，减少不同类型内容在边界处的显示差异。
  * 调整了形状、SVG 和文字等内容的区域计算方式，使缩放后的裁切和留白更稳定。
  * 提升了边缘渲染的一致性，整体视觉更平滑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->