### PR TITLE
Unify widget dirty rect padding and frame outset calculations

### DIFF
--- a/Inkeys/Inkeys/UI/Bar/Bar.RenderingAttribute.cppm
+++ b/Inkeys/Inkeys/UI/Bar/Bar.RenderingAttribute.cppm
@@ -10,6 +10,8 @@ import :State;
 class BarRenderingAttribute
 {
 public:
+	static constexpr int dirtyAntialiasPadding = 3;
+
 	static void UnionRectInPlace(RECT& target, const RECT& add)
 	{
 		// 新增矩形无效，直接返回
@@ -27,48 +29,54 @@ public:
 		target.bottom = max(target.bottom, add.bottom);
 	}
 
+	static int GetFrameDirtyOutset(const optional<BarUiValueClass>& ft, double tarZoom)
+	{
+		if (!ft.has_value()) return 0;
+
+		// 边框外扩需要折算到设备像素，固定抗锯齿余量在矩形计算处统一追加。
+		return static_cast<int>(ceil(ft.value().val * tarZoom));
+	}
+
 	static RECT GetWeigetRect(const BarUiShapeClass& shape, double tarZoom)
 	{
-		int ft = 0;
-		if (shape.ft.has_value()) ft = static_cast<int>(ceil(shape.ft.value().val));
+		int ft = GetFrameDirtyOutset(shape.ft, tarZoom) + dirtyAntialiasPadding;
 
 		RECT ret;
 		ret.left = static_cast<LONG>(floor(shape.inhX * tarZoom) - ft);
 		ret.top = static_cast<LONG>(floor(shape.inhY * tarZoom) - ft);
-		ret.right = static_cast<LONG>(ceil((shape.inhX + shape.w.val) * tarZoom) + ft) + 1;
-		ret.bottom = static_cast<LONG>(ceil((shape.inhY + shape.h.val) * tarZoom) + ft) + 1;
+		ret.right = static_cast<LONG>(ceil((shape.inhX + shape.w.val) * tarZoom) + ft);
+		ret.bottom = static_cast<LONG>(ceil((shape.inhY + shape.h.val) * tarZoom) + ft);
 
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiSuperellipseClass& superellipse, double tarZoom)
 	{
-		int ft = 0;
-		if (superellipse.ft.has_value()) ft = static_cast<int>(ceil(superellipse.ft.value().val));
+		int ft = GetFrameDirtyOutset(superellipse.ft, tarZoom) + dirtyAntialiasPadding;
 
 		RECT ret;
 		ret.left = static_cast<LONG>(floor(superellipse.inhX * tarZoom) - ft);
 		ret.top = static_cast<LONG>(floor(superellipse.inhY * tarZoom) - ft);
-		ret.right = static_cast<LONG>(ceil((superellipse.inhX + superellipse.w.val) * tarZoom) + ft) + 1;
-		ret.bottom = static_cast<LONG>(ceil((superellipse.inhY + superellipse.h.val) * tarZoom) + ft) + 1;
+		ret.right = static_cast<LONG>(ceil((superellipse.inhX + superellipse.w.val) * tarZoom) + ft);
+		ret.bottom = static_cast<LONG>(ceil((superellipse.inhY + superellipse.h.val) * tarZoom) + ft);
 
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiSVGClass& svg, double tarZoom)
 	{
 		RECT ret;
-		ret.left = static_cast<LONG>(floor(svg.inhX * tarZoom));
-		ret.top = static_cast<LONG>(floor(svg.inhY * tarZoom));
-		ret.right = static_cast<LONG>(ceil((svg.inhX + svg.w.val) * tarZoom)) + 1;
-		ret.bottom = static_cast<LONG>(ceil((svg.inhY + svg.h.val) * tarZoom)) + 1;
+		ret.left = static_cast<LONG>(floor(svg.inhX * tarZoom) - dirtyAntialiasPadding);
+		ret.top = static_cast<LONG>(floor(svg.inhY * tarZoom) - dirtyAntialiasPadding);
+		ret.right = static_cast<LONG>(ceil((svg.inhX + svg.w.val) * tarZoom) + dirtyAntialiasPadding);
+		ret.bottom = static_cast<LONG>(ceil((svg.inhY + svg.h.val) * tarZoom) + dirtyAntialiasPadding);
 		return ret;
 	}
 	static RECT GetWeigetRect(const BarUiWordClass& word, double tarZoom)
 	{
 		RECT ret;
-		ret.left = static_cast<LONG>(floor(word.inhX * tarZoom));
-		ret.top = static_cast<LONG>(floor(word.inhY * tarZoom));
-		ret.right = static_cast<LONG>(ceil((word.inhX + word.w.val) * tarZoom)) + 1;
-		ret.bottom = static_cast<LONG>(ceil((word.inhY + word.h.val) * tarZoom)) + 1;
+		ret.left = static_cast<LONG>(floor(word.inhX * tarZoom) - dirtyAntialiasPadding);
+		ret.top = static_cast<LONG>(floor(word.inhY * tarZoom) - dirtyAntialiasPadding);
+		ret.right = static_cast<LONG>(ceil((word.inhX + word.w.val) * tarZoom) + dirtyAntialiasPadding);
+		ret.bottom = static_cast<LONG>(ceil((word.inhY + word.h.val) * tarZoom) + dirtyAntialiasPadding);
 		return ret;
 	}
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了控件脏矩形的计算方式，使边界扩展更一致，减少缩放场景下的裁剪或重绘异常。
  * 改进了抗锯齿相关的边缘预留处理，提升不同图形内容在界面中的显示稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->