### PR TITLE
Use 123clouddisk CDN host for update checks

### DIFF
--- a/Inkeys/Inkeys/Net/Net.Update.Download.cpp
+++ b/Inkeys/Inkeys/Net/Net.Update.Download.cpp
@@ -26,7 +26,7 @@ std::string GetEditionInformation(std::string referer)
 
 	// 尝试主地址
 	{
-		httplib::SSLClient scli("vip.123pan.cn");
+		httplib::SSLClient scli("1709404.cdn.123clouddisk.com");
 		scli.set_follow_location(true);
 		scli.set_connection_timeout(5);
 		scli.set_read_timeout(10);
@@ -36,7 +36,7 @@ std::string GetEditionInformation(std::string referer)
 		if (!res || res->status != 200)
 		{
 			// 失败后尝试使用 Http 连接
-			httplib::Client cli("vip.123pan.cn");
+			httplib::Client cli("1709404.cdn.123clouddisk.com");
 			cli.set_follow_location(true);
 			cli.set_connection_timeout(5);
 			cli.set_read_timeout(10);


### PR DESCRIPTION
## Summary

- Route the primary update metadata request through `1709404.cdn.123clouddisk.com`.
- Apply the same host to both the HTTPS request and HTTP fallback.
- Keep the existing backup endpoint unchanged.

## Why

The previous `vip.123pan.cn` host should be replaced by the dedicated CDN host so update checks use the intended distribution endpoint.

## Impact

Inkeys update checks will request `version.json` from the new primary CDN address before falling back to the existing backup server.

## Validation

- Compared the branch against `dev`.
- Verified an isolated merge into the current `dev` completes without conflicts.
- No full application build was run for this URL-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 优化版本信息获取的网络地址配置。
  * 提升在特定网络环境下获取更新信息的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->